### PR TITLE
Add support for payload Nans

### DIFF
--- a/decimal64.go
+++ b/decimal64.go
@@ -455,9 +455,15 @@ func numDecimalDigits(n uint64) int {
 	return numDigits + 1
 }
 
-// propagateNan returns true if flavor1 should be propagated else false if flavor2 should be propagated
+// propagateNan returns the decimal pointer to the NaN that is to be propogated
 func propagateNan(dp, ep *decParts) *Decimal64 {
-	if dp.fl == flSNaN || dp.fl == flQNaN {
+	if dp.fl == flSNaN {
+		return dp.dec
+	}
+	if ep.fl == flSNaN {
+		return ep.dec
+	}
+	if dp.fl == flQNaN {
 		return dp.dec
 	}
 	return ep.dec

--- a/decimal64fmt.go
+++ b/decimal64fmt.go
@@ -31,18 +31,14 @@ func appendUint64(buf []byte, n, limit uint64) []byte {
 // Append appends the text representation of d to buf.
 func (d Decimal64) Append(buf []byte, format byte, prec int) []byte {
 	flavor, sign, exp, significand := d.parts()
-	switch flavor {
-	case flQNaN, flSNaN:
-		return append(buf, []byte("nan")...)
-	case flInf:
-		if sign == 0 {
-			return append(buf, []byte("inf")...)
-		}
-		return append(buf, []byte("-inf")...)
-	}
-
 	if sign == 1 {
 		buf = append(buf, '-')
+	}
+	switch flavor {
+	case flQNaN, flSNaN:
+		return appendUint64(append(buf, []byte("NaN")...), significand, 10000)
+	case flInf:
+		return append(buf, []byte("inf")...)
 	}
 
 formatBlock:

--- a/decimal64fmt_test.go
+++ b/decimal64fmt_test.go
@@ -71,17 +71,22 @@ func TestDecimal64Append(t *testing.T) {
 		require.Equal(expected, string(d.Append([]byte{}, format, prec)))
 	}
 
-	// for i := int64(-1000); i <= 1000; i++ {
-	// 	require.Equal(
-	// 		strconv.FormatInt(i, 10),
-	// 		string(NewDecimal64FromInt64(i).Append([]byte{}, 'g', 0)),
-	// 	)
-	// }
+	for i := int64(-1000); i <= 1000; i++ {
+		require.Equal(
+			strconv.FormatInt(i, 10),
+			string(NewDecimal64FromInt64(i).Append([]byte{}, 'g', 0)),
+		)
+	}
 
-	// requireAppend("NaN", QNaN64, 'g', 0)
-	// requireAppend("inf", Infinity64, 'g', 0)
-	// requireAppend("-inf", NegInfinity64, 'g', 0)
-	// requireAppend("-0", NegZero64, 'g', 0)
+	requireAppend("NaN", QNaN64, 'g', 0)
+	requireAppend("inf", Infinity64, 'g', 0)
+	requireAppend("-inf", NegInfinity64, 'g', 0)
+	requireAppend("-0", NegZero64, 'g', 0)
+	requireAppend("NaN", QNaN64, 'f', 0)
+	requireAppend("NaN", SNaN64, 'f', 0)
+	requireAppend("inf", Infinity64, 'f', 0)
+	requireAppend("-inf", NegInfinity64, 'f', 0)
+	requireAppend("%w", Zero64, 'w', 0)
 
 	requireAppend("1.23456789e+8", MustParseDecimal64("123456789"), 'e', 0)
 	requireAppend("1.23456789e+18", MustParseDecimal64("123456789e10"), 'e', 0)
@@ -93,13 +98,6 @@ func TestDecimal64Append(t *testing.T) {
 	requireAppend("1.23456789e-18", MustParseDecimal64("123456789e-26"), 'g', 0)
 	requireAppend("1.23456789e+18", MustParseDecimal64("123456789e10"), 'g', 0)
 
-	requireAppend("nan", QNaN64, 'f', 0)
-	requireAppend("nan", SNaN64, 'f', 0)
-
-	requireAppend("inf", Infinity64, 'f', 0)
-	requireAppend("-inf", NegInfinity64, 'f', 0)
-
-	requireAppend("%w", Zero64, 'w', 0)
 }
 
 func BenchmarkDecimal64Append(b *testing.B) {

--- a/decimal64scan.go
+++ b/decimal64scan.go
@@ -46,21 +46,21 @@ func (d *Decimal64) Scan(state fmt.ScanState, verb rune) error {
 	if err != nil {
 		return err
 	}
-	switch word {
+	switch strings.ToLower(word) {
 	case "":
-	case "inf", "Inf", "infinity", "Infinity", "∞":
+	case "inf", "infinity", "∞":
 		if sign == 0 {
 			*d = Infinity64
 		} else {
 			*d = NegInfinity64
 		}
 		return nil
-	case "nan", "NaN", "qNaN", "qnan", "Nan", "qNan":
+	case "nan", "qnan":
 		payload, _ := tokenString(state, unicode.IsDigit)
 		payloadInt, _ := parseUint(payload)
 		*d = newPayloadNan(sign, flQNaN, uint64(payloadInt))
 		return nil
-	case "sNaN", "snan", "sNan":
+	case "snan":
 		payload, _ := tokenString(state, unicode.IsDigit)
 		payloadInt, _ := parseUint(payload)
 		*d = newPayloadNan(sign, flSNaN, uint64(payloadInt))

--- a/dectest/ddAdd.decTest
+++ b/dectest/ddAdd.decTest
@@ -744,21 +744,21 @@ rounding: half_even
 # ddadd7867 add -1000    NaN8   ->  NaN8
 # ddadd7868 add  1000    NaN9   ->  NaN9
 # ddadd7869 add  Inf    +NaN10  ->  NaN10
-# ddadd7871 add  sNaN11  -Inf   ->  NaN11  Invalid_operation
-# ddadd7872 add  sNaN12  -1000  ->  NaN12  Invalid_operation
-# ddadd7873 add  sNaN13   1000  ->  NaN13  Invalid_operation
-# ddadd7874 add  sNaN14   NaN17 ->  NaN14  Invalid_operation
-# ddadd7875 add  sNaN15  sNaN18 ->  NaN15  Invalid_operation
-# ddadd7876 add  NaN16   sNaN19 ->  NaN19  Invalid_operation
-# ddadd7877 add -Inf    +sNaN20 ->  NaN20  Invalid_operation
-# ddadd7878 add -1000    sNaN21 ->  NaN21  Invalid_operation
-# ddadd7879 add  1000    sNaN22 ->  NaN22  Invalid_operation
-# ddadd7880 add  Inf     sNaN23 ->  NaN23  Invalid_operation
-# ddadd7881 add +NaN25  +sNaN24 ->  NaN24  Invalid_operation
-# ddadd7882 add -NaN26    NaN28 -> -NaN26
-# ddadd7883 add -sNaN27  sNaN29 -> -NaN27  Invalid_operation
-# ddadd7884 add  1000    -NaN30 -> -NaN30
-# ddadd7885 add  1000   -sNaN31 -> -NaN31  Invalid_operation
+ddadd7871 add  sNaN11  -Inf   ->  NaN11  Invalid_operation
+ddadd7872 add  sNaN12  -1000  ->  NaN12  Invalid_operation
+ddadd7873 add  sNaN13   1000  ->  NaN13  Invalid_operation
+ddadd7874 add  sNaN14   NaN17 ->  NaN14  Invalid_operation
+ddadd7875 add  sNaN15  sNaN18 ->  NaN15  Invalid_operation
+ddadd7876 add  NaN16   sNaN19 ->  NaN19  Invalid_operation
+ddadd7877 add -Inf    +sNaN20 ->  NaN20  Invalid_operation
+ddadd7878 add -1000    sNaN21 ->  NaN21  Invalid_operation
+ddadd7879 add  1000    sNaN22 ->  NaN22  Invalid_operation
+ddadd7880 add  Inf     sNaN23 ->  NaN23  Invalid_operation
+ddadd7881 add +NaN25  +sNaN24 ->  NaN24  Invalid_operation
+ddadd7882 add -NaN26    NaN28 -> -NaN26
+ddadd7883 add -sNaN27  sNaN29 -> -NaN27  Invalid_operation
+ddadd7884 add  1000    -NaN30 -> -NaN30
+ddadd7885 add  1000   -sNaN31 -> -NaN31  Invalid_operation
 #
 # -- Here we explore near the boundary of rounding a subnormal to Nmin
 # ddadd7575 add  1E-383 -1E-398 ->  9.99999999999999E-384  Subnormal


### PR DESCRIPTION
Add support for payload Nans; both signalling and quiet nans that use the significand field for diagnostic information
examples: ```NaN12, -NaN13, sNaN19```


