### PR TITLE
Add context oriented methods and line by line test suite parser

### DIFF
--- a/decimal64.go
+++ b/decimal64.go
@@ -8,7 +8,6 @@ import (
 type flavor int
 type roundingMode int
 type discardedDigit int
-type decErr int
 
 const (
 	eq0 discardedDigit = 1 << iota
@@ -30,16 +29,6 @@ const (
 	roundDown
 )
 
-// // TODO: implement returns of these error types
-// const (
-// 	noError decErr = iota
-// 	invalidOperation
-// 	divisionByzero
-// 	inexact
-// 	overflow
-// 	underflow
-// )
-
 // Decimal64 represents an IEEE 754 64-bit floating point decimal number.
 // It uses the binary representation method.
 type Decimal64 struct {
@@ -56,11 +45,9 @@ type decParts struct {
 	dec         *Decimal64
 }
 
-// Context64 stores the rounding type and and exceptions needed to be signalled
+// Context64 stores the rounding type
 type Context64 struct {
 	roundingMode roundingMode
-	// TODO:use exceptions in order to report errors to calling fucntion
-	// exceptions decErr
 }
 
 var powersOf10 = []uint64{

--- a/decimal64.go
+++ b/decimal64.go
@@ -8,6 +8,7 @@ import (
 type flavor int
 type roundingMode int
 type discardedDigit int
+type decErr int
 
 const (
 	eq0 discardedDigit = 1 << iota
@@ -26,7 +27,18 @@ const (
 const (
 	roundHalfUp roundingMode = iota
 	roundHalfEven
+	roundDown
 )
+
+// // TODO: implement returns of these error types
+// const (
+// 	noError decErr = iota
+// 	invalidOperation
+// 	divisionByzero
+// 	inexact
+// 	overflow
+// 	underflow
+// )
 
 // Decimal64 represents an IEEE 754 64-bit floating point decimal number.
 // It uses the binary representation method.
@@ -42,6 +54,13 @@ type decParts struct {
 	significand uint64
 	mag         int
 	dec         *Decimal64
+}
+
+// Context64 stores the rounding type and and exceptions needed to be signalled
+type Context64 struct {
+	roundingMode roundingMode
+	// TODO:use exceptions in order to report errors to calling fucntion
+	// exceptions decErr
 }
 
 var powersOf10 = []uint64{
@@ -77,8 +96,8 @@ func (context roundingMode) round(significand uint64, rndStatus discardedDigit) 
 		if (rndStatus == eq5 && significand%2 == 1) || rndStatus == gt5 {
 			return significand + 1
 		}
-		// case roundDown: // TODO: implement proper down behaviour
-		// 	return significand
+	case roundDown: // TODO: implement proper down behaviour
+		return significand
 		// case roundFloor:// TODO: implement proper Floor behaviour
 		// 	return significand
 		// case roundCeiling: //TODO: fine tune ceiling,

--- a/decimal64const.go
+++ b/decimal64const.go
@@ -53,3 +53,6 @@ var Min64 = newFromParts(0, -398, 1)
 
 var zeroes = []Decimal64{Zero64, NegZero64}
 var infinities = []Decimal64{Infinity64, NegInfinity64}
+
+// defaultContext is the context that Arithmetic functions will use in order to do calculations
+var defaultContext = Context64{roundHalfUp}

--- a/decimal64const.go
+++ b/decimal64const.go
@@ -54,5 +54,5 @@ var Min64 = newFromParts(0, -398, 1)
 var zeroes = []Decimal64{Zero64, NegZero64}
 var infinities = []Decimal64{Infinity64, NegInfinity64}
 
-// defaultContext is the context that Arithmetic functions will use in order to do calculations
-var defaultContext = Context64{roundHalfUp}
+// DefaultContext is the context that Arithmetic functions will use in order to do calculations
+var DefaultContext = Context64{roundHalfUp}

--- a/decimal64math.go
+++ b/decimal64math.go
@@ -5,19 +5,19 @@ func (d Decimal64) Abs() Decimal64 {
 	return Decimal64{^neg64 & uint64(d.bits)}
 }
 
-// Add computes d + e with default rounding set to half_up
+// Add computes d + e with default rounding
 func (d Decimal64) Add(e Decimal64) Decimal64 {
-	return defaultContext.Add(d, e)
+	return DefaultContext.Add(d, e)
 }
 
-// FMA computes d*e + f with default rounding set to half_up
+// FMA computes d*e + f with default rounding
 func (d Decimal64) FMA(e, f Decimal64) Decimal64 {
-	return defaultContext.FMA(d, e, f)
+	return DefaultContext.FMA(d, e, f)
 }
 
-// Mul computes d * e with default rounding set to half_even
+// Mul computes d * e with default rounding
 func (d Decimal64) Mul(e Decimal64) Decimal64 {
-	return Context64{roundHalfEven}.Mul(d, e)
+	return DefaultContext.Mul(d, e)
 }
 
 // Sub returns d - e.
@@ -53,7 +53,7 @@ func (d Decimal64) Cmp(e Decimal64) int {
 
 // Neg computes -d.
 func (d Decimal64) Neg() Decimal64 {
-	return Decimal64{neg64 ^ uint64(d.bits)}
+	return Decimal64{neg64 ^ d.bits}
 }
 
 // Quo computes d / e.

--- a/decimal64math.go
+++ b/decimal64math.go
@@ -10,6 +10,121 @@ func (d Decimal64) Add(e Decimal64) Decimal64 {
 	return defaultContext.Add(d, e)
 }
 
+// FMA computes d*e + f with default rounding set to half_up
+func (d Decimal64) FMA(e, f Decimal64) Decimal64 {
+	return defaultContext.FMA(d, e, f)
+}
+
+// Mul computes d * e with default rounding set to half_even
+func (d Decimal64) Mul(e Decimal64) Decimal64 {
+	return Context64{roundHalfEven}.Mul(d, e)
+}
+
+// Sub returns d - e.
+func (d Decimal64) Sub(e Decimal64) Decimal64 {
+	return d.Add(e.Neg())
+}
+
+// Cmp returns:
+//
+//   -2 if d or e is NaN
+//   -1 if d <  e
+//    0 if d == e (incl. -0 == 0, -Inf == -Inf, and +Inf == +Inf)
+//   +1 if d >  e
+//
+func (d Decimal64) Cmp(e Decimal64) int {
+	flavor1, _, _, significand1 := d.parts()
+	flavor2, _, _, significand2 := e.parts()
+	if flavor1 == flSNaN || flavor2 == flSNaN {
+		return -2
+	}
+	if flavor1 == flQNaN || flavor2 == flQNaN {
+		return -2
+	}
+	if significand1 == 0 && significand2 == 0 {
+		return 0
+	}
+	if d == e {
+		return 0
+	}
+	d = d.Sub(e)
+	return 1 - 2*int(d.bits>>63)
+}
+
+// Neg computes -d.
+func (d Decimal64) Neg() Decimal64 {
+	return Decimal64{neg64 ^ uint64(d.bits)}
+}
+
+// Quo computes d / e.
+func (d Decimal64) Quo(e Decimal64) Decimal64 {
+	flavor1, sign1, exp1, significand1 := d.parts()
+	flavor2, sign2, exp2, significand2 := e.parts()
+	if flavor1 == flSNaN || flavor2 == flSNaN {
+		return SNaN64
+	}
+	if flavor1 == flQNaN || flavor2 == flQNaN {
+		return QNaN64
+	}
+	sign := sign1 ^ sign2
+	if d == Zero64 || d == NegZero64 {
+		if e == Zero64 || e == NegZero64 {
+			return QNaN64
+		}
+		return zeroes[sign]
+	}
+	if flavor1 == flInf {
+		if flavor2 == flInf {
+			return QNaN64
+		}
+		return infinities[sign]
+	}
+	if flavor2 == flInf {
+		return zeroes[sign]
+	}
+	if e == Zero64 || e == NegZero64 {
+		return infinities[sign1]
+	}
+	exp := exp1 - exp2 - 16
+	significand := umul64(10*decimal64Base, significand1).div64(significand2)
+	exp, significand.lo = renormalize(exp, significand.lo)
+	if significand.lo > maxSig || exp > expMax {
+		return infinities[sign]
+	}
+
+	return newFromParts(sign, exp, significand.lo)
+}
+
+// Sqrt computes √d.
+func (d Decimal64) Sqrt() Decimal64 {
+	flavor, sign, exp, significand := d.parts()
+	switch flavor {
+	case flInf:
+		if sign == 1 {
+			return QNaN64
+		}
+		return d
+	case flQNaN:
+		return d
+	case flSNaN:
+		return SNaN64
+	case flNormal:
+	}
+	if significand == 0 {
+		return d
+	}
+	if sign == 1 {
+		return QNaN64
+	}
+	if exp&1 == 1 {
+		exp--
+		significand *= 10
+	}
+	sqrt := umul64(10*decimal64Base, significand).sqrt()
+	exp, significand = renormalize(exp/2-8, sqrt)
+	return newFromParts(sign, exp, significand)
+}
+
 // Add computes d + e
 func (ctx Context64) Add(d, e Decimal64) Decimal64 {
 	dp := d.getParts()
@@ -67,37 +182,6 @@ func (ctx Context64) Add(d, e Decimal64) Decimal64 {
 		return infinities[ans.sign]
 	}
 	return newFromParts(ans.sign, ans.exp, ans.significand)
-}
-
-// Cmp returns:
-//
-//   -2 if d or e is NaN
-//   -1 if d <  e
-//    0 if d == e (incl. -0 == 0, -Inf == -Inf, and +Inf == +Inf)
-//   +1 if d >  e
-//
-func (d Decimal64) Cmp(e Decimal64) int {
-	flavor1, _, _, significand1 := d.parts()
-	flavor2, _, _, significand2 := e.parts()
-	if flavor1 == flSNaN || flavor2 == flSNaN {
-		return -2
-	}
-	if flavor1 == flQNaN || flavor2 == flQNaN {
-		return -2
-	}
-	if significand1 == 0 && significand2 == 0 {
-		return 0
-	}
-	if d == e {
-		return 0
-	}
-	d = d.Sub(e)
-	return 1 - 2*int(d.bits>>63)
-}
-
-// FMA computes d*e + f with default rounding set to half_up
-func (d Decimal64) FMA(e, f Decimal64) Decimal64 {
-	return defaultContext.FMA(d, e, f)
 }
 
 // FMA computes d*e + f
@@ -203,11 +287,6 @@ func (ctx Context64) FMA(d, e, f Decimal64) Decimal64 {
 	return newFromParts(ans.sign, ans.exp, ans.significand)
 }
 
-// Mul computes d * e with default rounding set to half_even
-func (d Decimal64) Mul(e Decimal64) Decimal64 {
-	return Context64{roundHalfEven}.Mul(d, e)
-}
-
 // Mul computes d * e
 func (ctx Context64) Mul(d, e Decimal64) Decimal64 {
 	dp := d.getParts()
@@ -244,83 +323,4 @@ func (ctx Context64) Mul(d, e Decimal64) Decimal64 {
 		return infinities[ans.sign]
 	}
 	return newFromParts(ans.sign, ans.exp, ans.significand)
-}
-
-// Neg computes -d.
-func (d Decimal64) Neg() Decimal64 {
-	return Decimal64{neg64 ^ uint64(d.bits)}
-}
-
-// Quo computes d / e.
-func (d Decimal64) Quo(e Decimal64) Decimal64 {
-	flavor1, sign1, exp1, significand1 := d.parts()
-	flavor2, sign2, exp2, significand2 := e.parts()
-	if flavor1 == flSNaN || flavor2 == flSNaN {
-		return SNaN64
-	}
-	if flavor1 == flQNaN || flavor2 == flQNaN {
-		return QNaN64
-	}
-	sign := sign1 ^ sign2
-	if d == Zero64 || d == NegZero64 {
-		if e == Zero64 || e == NegZero64 {
-			return QNaN64
-		}
-		return zeroes[sign]
-	}
-	if flavor1 == flInf {
-		if flavor2 == flInf {
-			return QNaN64
-		}
-		return infinities[sign]
-	}
-	if flavor2 == flInf {
-		return zeroes[sign]
-	}
-	if e == Zero64 || e == NegZero64 {
-		return infinities[sign1]
-	}
-	exp := exp1 - exp2 - 16
-	significand := umul64(10*decimal64Base, significand1).div64(significand2)
-	exp, significand.lo = renormalize(exp, significand.lo)
-	if significand.lo > maxSig || exp > expMax {
-		return infinities[sign]
-	}
-
-	return newFromParts(sign, exp, significand.lo)
-}
-
-// Sqrt computes √d.
-func (d Decimal64) Sqrt() Decimal64 {
-	flavor, sign, exp, significand := d.parts()
-	switch flavor {
-	case flInf:
-		if sign == 1 {
-			return QNaN64
-		}
-		return d
-	case flQNaN:
-		return d
-	case flSNaN:
-		return SNaN64
-	case flNormal:
-	}
-	if significand == 0 {
-		return d
-	}
-	if sign == 1 {
-		return QNaN64
-	}
-	if exp&1 == 1 {
-		exp--
-		significand *= 10
-	}
-	sqrt := umul64(10*decimal64Base, significand).sqrt()
-	exp, significand = renormalize(exp/2-8, sqrt)
-	return newFromParts(sign, exp, significand)
-}
-
-// Sub returns d - e.
-func (d Decimal64) Sub(e Decimal64) Decimal64 {
-	return d.Add(e.Neg())
 }


### PR DESCRIPTION
adds DecContext struct with roundingMode for setting rounding mode and exceptions witch will be used in future

DecimalSuite_test now scans tests line by line in order to set rounding methods as it goes and has ability to ignore rounding methods if needed