### PR TITLE
Fix compare function

### DIFF
--- a/decimal64math.go
+++ b/decimal64math.go
@@ -38,15 +38,12 @@ func (d Decimal64) Quo(e Decimal64) Decimal64 {
 //   +1 if d >  e
 //
 func (d Decimal64) Cmp(e Decimal64) int {
-	flavor1, _, _, significand1 := d.parts()
-	flavor2, _, _, significand2 := e.parts()
-	if flavor1 == flSNaN || flavor2 == flSNaN {
+	dp := d.getParts()
+	ep := e.getParts()
+	if dec := propagateNan(&dp, &ep); dec != nil {
 		return -2
 	}
-	if flavor1 == flQNaN || flavor2 == flQNaN {
-		return -2
-	}
-	if significand1 == 0 && significand2 == 0 {
+	if dp.isZero() && ep.isZero() {
 		return 0
 	}
 	if d == e {

--- a/decimalSuite_test.go
+++ b/decimalSuite_test.go
@@ -36,7 +36,7 @@ var tests = []string{
 	"dectest/ddFMA.decTest",
 	"dectest/ddClass.decTest",
 	// TODO: Implement following tests
-	// "dectest/ddCompare.decTest",
+	"dectest/ddCompare.decTest",
 	// 	"dectest/ddAbs.decTest",
 	// 	"dectest/ddCopysign.decTest",
 	"dectest/ddDivide.decTest",
@@ -203,6 +203,9 @@ func runTest(context Context64, testVals decValContainer, testValStrings testCas
 	calcRestul := calculatedContainer.calculated
 
 	if calculatedContainer.calculatedString != "" {
+		if testValStrings.testFunc == "compare" && calculatedContainer.calculatedString == "-2" && testVals.expected.IsNaN() {
+			return nil
+		}
 		if calculatedContainer.calculatedString != testValStrings.expectedResult {
 			return fmt.Errorf(
 				"failed:\n%scalculated result: %s",
@@ -211,6 +214,7 @@ func runTest(context Context64, testVals decValContainer, testValStrings testCas
 		}
 
 	} else if calcRestul.IsNaN() || testVals.expected.IsNaN() {
+
 		if testVals.expected.String() != calcRestul.String() {
 			return fmt.Errorf(
 				"failed NaN TEST:\n%scalculated result: %v",


### PR DESCRIPTION
Compare function currently returns incorrect values for `-inf Cmp inf` will be evaluated to `0` should be `-1` as `-inf < inf` 