### PR TITLE
dd abs

### DIFF
--- a/decimal64math.go
+++ b/decimal64math.go
@@ -2,6 +2,9 @@ package decimal
 
 // Abs computes ||d||.
 func (d Decimal64) Abs() Decimal64 {
+	if d.IsNaN() {
+		return d
+	}
 	return Decimal64{^neg64 & uint64(d.bits)}
 }
 

--- a/decimalSuite_test.go
+++ b/decimalSuite_test.go
@@ -37,8 +37,8 @@ var tests = []string{
 	"dectest/ddClass.decTest",
 	// TODO: Implement following tests
 	"dectest/ddCompare.decTest",
-	// 	"dectest/ddAbs.decTest",
-	// 	"dectest/ddCopysign.decTest",
+	"dectest/ddAbs.decTest",
+	// "dectest/ddCopysign.decTest",
 	"dectest/ddDivide.decTest",
 	// 	"dectest/ddLogB.decTest",
 	// 	"dectest/ddMin.decTest",


### PR DESCRIPTION
fixes issue #58
Returns original nan without flipping sign 
Reasoning behind this change is that no arithmetic is meant to occur on NaNs; they are only meant to be propagated 