### PR TITLE
Fix decimal for 32 bit compilers

### DIFF
--- a/decimal64_test.go
+++ b/decimal64_test.go
@@ -27,7 +27,7 @@ func TestNew64FromInt64(t *testing.T) {
 }
 
 func TestNew64FromInt64Big(t *testing.T) {
-	const limit = decimal64Base
+	const limit = int64(decimal64Base)
 	const step = limit / 997
 	for i := -int64(limit); i <= limit; i += step {
 		d := New64FromInt64(i)
@@ -67,16 +67,16 @@ func TestDecimal64Int64(t *testing.T) {
 
 	require.EqualValues(0, QNaN64.Int64())
 
-	require.EqualValues(math.MaxInt64, Infinity64.Int64())
-	require.EqualValues(math.MinInt64, NegInfinity64.Int64())
+	require.EqualValues(int64(math.MaxInt64), Infinity64.Int64())
+	require.EqualValues(int64(math.MinInt64), NegInfinity64.Int64())
 
 	googol, err := Parse64("1e100")
 	require.NoError(err)
-	require.EqualValues(math.MaxInt64, googol.Int64())
+	require.EqualValues(int64(math.MaxInt64), googol.Int64())
 
 	long, err := Parse64("91234567890123456789e20")
 	require.NoError(err)
-	require.EqualValues(math.MaxInt64, long.Int64())
+	require.EqualValues(int64(math.MaxInt64), long.Int64())
 }
 
 func TestDecimal64IsInf(t *testing.T) {

--- a/decimal64const.go
+++ b/decimal64const.go
@@ -34,7 +34,7 @@ var neg64 uint64 = 0x80 << 56
 var inf64 uint64 = 0x78 << 56
 
 // 1E15
-const decimal64Base = 1000 * 1000 * 1000 * 1000 * 1000
+const decimal64Base uint64 = 1000 * 1000 * 1000 * 1000 * 1000
 
 // maxSig is the maximum significand possible that fits in 16 decimal places.
 const maxSig = 10*decimal64Base - 1

--- a/decimal64scan.go
+++ b/decimal64scan.go
@@ -150,7 +150,7 @@ func parseUint(s string) (int64, int) {
 	var a int64
 	var exp int
 	for i, c := range s {
-		if a >= decimal64Base {
+		if a >= int64(decimal64Base) {
 			exp = len(s) - i
 			break
 		}

--- a/uint128_test.go
+++ b/uint128_test.go
@@ -22,8 +22,8 @@ func TestUint128Sqrt(t *testing.T) {
 	require.EqualValues(t, 2, uint128T{4, 0}.sqrt())
 	require.EqualValues(t, 2, uint128T{8, 0}.sqrt())
 	require.EqualValues(t, 3, uint128T{9, 0}.sqrt())
-	require.EqualValues(t, 1<<32, uint128T{0, 1}.sqrt())
-	require.EqualValues(t, 2<<32, uint128T{0, 4}.sqrt())
+	require.EqualValues(t, int64(1<<32), uint128T{0, 1}.sqrt())
+	require.EqualValues(t, int64(2<<32), uint128T{0, 4}.sqrt())
 }
 
 func TestUint128DivBy10(t *testing.T) {


### PR DESCRIPTION
Fixes #64

Changes proposed
- Types const `decimal64Base` as uint64
- Adds explicit typecasting to subsequent usage of const

This therefore allows for the use by 32 bit systems so that `decimal64Base` isn't cast into a 32 bit `int`