### PR TITLE
Touch up doc comments + export Context64.Rounding

### DIFF
--- a/decimal64const.go
+++ b/decimal64const.go
@@ -1,33 +1,36 @@
 package decimal
 
-// Zero64 represents 0 as a Decimal64.
+// Zero64 is 0 represented as a Decimal64.
 var Zero64 = newFromParts(0, 0, 0)
 
-// NegZero64 represents -0 as a Decimal64.
+// NegZero64 is -0 represented as a Decimal64.
+// Note that Zero64 != NegZero64, but Zero64.Equal(NegZero64) returns true.
 var NegZero64 = newFromParts(1, 0, 0)
 
-// One64 represents 1 as a Decimal64.
+// One64 is 1 represented as a Decimal64.
 var One64 = newFromParts(0, -15, decimal64Base)
 
-// NegOne64 represents -1 as a Decimal64.
+// NegOne64 is -1 represented as a Decimal64.
 var NegOne64 = newFromParts(1, -15, decimal64Base)
 
-// Infinity64 represents ∞ as a Decimal64.
+// Infinity64 is ∞ represented as a Decimal64.
 var Infinity64 = new64(inf64)
 
-// NegInfinity64 represents -∞ as a Decimal64.
+// NegInfinity64 is -∞ represented as a Decimal64.
 var NegInfinity64 = new64(neg64 | inf64)
 
-// QNaN64 represents a quiet NaN as a Decimal64.
+// QNaN64 a quiet NaN represented as a Decimal64.
 var QNaN64 = new64(0x7c << 56)
 
-// SNaN64 represents a signalling NaN as a Decimal64.
+// SNaN64 a signalling NaN represented as a Decimal64.
+// Note that the decimal never signals on NaNs but some operations treat sNaN
+// differently to NaN.
 var SNaN64 = new64(0x7e << 56)
 
-// Pi64 represents π.
+// Pi64 represents the transcendental number π.
 var Pi64 = newFromParts(0, -15, 3_141592653589793)
 
-// E64 represents e (lim[n→∞](1+1/n)ⁿ).
+// E64 represents the transcendental number e (lim[n→∞](1+1/n)ⁿ).
 var E64 = newFromParts(0, -15, 2_718281828459045)
 
 const neg64 uint64 = 0x80 << 56
@@ -43,20 +46,29 @@ const maxSig = 10*decimal64Base - 1
 const expOffset = 398
 const expMax = 369
 
-// Max64  is the maximum number representable with a Decimal64.
+// Max64 is the highest finite number representable as a Decimal64.
+// It has the value 9.999999999999999E+384.
 var Max64 = newFromParts(0, expMax, maxSig)
 
-// NegMax64  is the minimum finite number (most negative) possible with Decimal64 (negative).
+// NegMax64 is the lowest finite number representable as a Decimal64.
+// It has the value -9.999999999999999E+384.
 var NegMax64 = newFromParts(1, expMax, maxSig)
 
 // Min64 is the closest positive number to zero.
+// It has the value 1E-398.
 var Min64 = newFromParts(0, -398, 1)
 
 // Min64 is the closest negative number to zero.
+// It has the value -1E-398.
 var NegMin64 = newFromParts(1, -398, 1)
 
 var zeroes = []Decimal64{Zero64, NegZero64}
 var infinities = []Decimal64{Infinity64, NegInfinity64}
 
-// DefaultContext is the context that Arithmetic functions will use in order to do calculations
-var DefaultContext = Context64{roundHalfUp}
+// DefaultContext64 is the context that arithmetic functions will use in order to
+// do calculations.
+// Setting this context to a different value will globally affect all
+// [Decimal64] methods whose behavior depends on context.
+// Note that all such methods are also available as direct methods of Context64.
+// It uses [HalfUp] rounding.
+var DefaultContext64 = Context64{Rounding: HalfUp}

--- a/decimal64math_test.go
+++ b/decimal64math_test.go
@@ -303,7 +303,7 @@ func rnd(ctx Context64, x, y uint64) uint64 {
 func TestRoundHalfUp(t *testing.T) {
 	t.Parallel()
 
-	ctx := Context64{roundingMode: roundHalfUp}
+	ctx := Context64{Rounding: HalfUp}
 	assert.Equal(t, uint64(10), rnd(ctx, 10, 1))
 	assert.Equal(t, uint64(10), rnd(ctx, 11, 1))
 	assert.Equal(t, uint64(20), rnd(ctx, 15, 1))
@@ -331,7 +331,7 @@ func TestRoundHalfUp(t *testing.T) {
 func TestRoundHalfEven(t *testing.T) {
 	t.Parallel()
 
-	ctx := Context64{roundingMode: roundHalfEven}
+	ctx := Context64{Rounding: HalfEven}
 	assert.Equal(t, uint64(10), rnd(ctx, 10, 1))
 	assert.Equal(t, uint64(10), rnd(ctx, 11, 1))
 	assert.Equal(t, uint64(20), rnd(ctx, 15, 1))
@@ -359,7 +359,7 @@ func TestRoundHalfEven(t *testing.T) {
 func TestRoundHDown(t *testing.T) {
 	t.Parallel()
 
-	ctx := Context64{roundingMode: roundDown}
+	ctx := Context64{Rounding: Down}
 	assert.Equal(t, uint64(10), rnd(ctx, 10, 1))
 	assert.Equal(t, uint64(10), rnd(ctx, 11, 1))
 	assert.Equal(t, uint64(10), rnd(ctx, 15, 1))

--- a/decimalSuite_test.go
+++ b/decimalSuite_test.go
@@ -141,11 +141,11 @@ func TestFromSuite(t *testing.T) {
 func setRoundingFromString(s string) Context64 {
 	switch s {
 	case "half_even":
-		return Context64{roundHalfEven}
+		return Context64{HalfEven}
 	case "half_up":
-		return Context64{roundHalfUp}
+		return Context64{HalfUp}
 	case "default":
-		return DefaultContext
+		return DefaultContext64
 	default:
 		panic("Rounding not supported" + s)
 	}


### PR DESCRIPTION
`Context64.Rounding` is now exported, allowing public access to alternate rounding strategies. Because `DefaultContext64` is an exported variable, it may be changed to alter the global rounding strategy.