### PR TITLE
cleanup + fix decimal_debug bugs

### DIFF
--- a/decimal64.go
+++ b/decimal64.go
@@ -108,32 +108,32 @@ func (ctx Rounding) round(significand uint64, rndStatus discardedDigit) uint64 {
 var ErrNaN64 error = Error("sNaN64")
 
 var small64s = []Decimal64{
-	newFromPartsStr(1, -14, 1*decimal64Base, "-10"),
+	new64str(newFromPartsRaw(1, -14, 1*decimal64Base).bits, "-10"),
 
-	newFromPartsStr(1, -15, 9*decimal64Base, "-9"),
-	newFromPartsStr(1, -15, 8*decimal64Base, "-8"),
-	newFromPartsStr(1, -15, 7*decimal64Base, "-7"),
-	newFromPartsStr(1, -15, 6*decimal64Base, "-6"),
-	newFromPartsStr(1, -15, 5*decimal64Base, "-5"),
-	newFromPartsStr(1, -15, 4*decimal64Base, "-4"),
-	newFromPartsStr(1, -15, 3*decimal64Base, "-3"),
-	newFromPartsStr(1, -15, 2*decimal64Base, "-2"),
-	newFromPartsStr(1, -15, 1*decimal64Base, "-1"),
+	new64str(newFromPartsRaw(1, -15, 9*decimal64Base).bits, "-9"),
+	new64str(newFromPartsRaw(1, -15, 8*decimal64Base).bits, "-8"),
+	new64str(newFromPartsRaw(1, -15, 7*decimal64Base).bits, "-7"),
+	new64str(newFromPartsRaw(1, -15, 6*decimal64Base).bits, "-6"),
+	new64str(newFromPartsRaw(1, -15, 5*decimal64Base).bits, "-5"),
+	new64str(newFromPartsRaw(1, -15, 4*decimal64Base).bits, "-4"),
+	new64str(newFromPartsRaw(1, -15, 3*decimal64Base).bits, "-3"),
+	new64str(newFromPartsRaw(1, -15, 2*decimal64Base).bits, "-2"),
+	new64str(newFromPartsRaw(1, -15, 1*decimal64Base).bits, "-1"),
 
 	// TODO: Decimal64{}?
-	newFromPartsStr(0, 0, 0, "0"),
+	new64str(newFromPartsRaw(0, 0, 0).bits, "0"),
 
-	newFromPartsStr(0, -15, 1*decimal64Base, "1"),
-	newFromPartsStr(0, -15, 2*decimal64Base, "2"),
-	newFromPartsStr(0, -15, 3*decimal64Base, "3"),
-	newFromPartsStr(0, -15, 4*decimal64Base, "4"),
-	newFromPartsStr(0, -15, 5*decimal64Base, "5"),
-	newFromPartsStr(0, -15, 6*decimal64Base, "6"),
-	newFromPartsStr(0, -15, 7*decimal64Base, "7"),
-	newFromPartsStr(0, -15, 8*decimal64Base, "8"),
-	newFromPartsStr(0, -15, 9*decimal64Base, "9"),
+	new64str(newFromPartsRaw(0, -15, 1*decimal64Base).bits, "1"),
+	new64str(newFromPartsRaw(0, -15, 2*decimal64Base).bits, "2"),
+	new64str(newFromPartsRaw(0, -15, 3*decimal64Base).bits, "3"),
+	new64str(newFromPartsRaw(0, -15, 4*decimal64Base).bits, "4"),
+	new64str(newFromPartsRaw(0, -15, 5*decimal64Base).bits, "5"),
+	new64str(newFromPartsRaw(0, -15, 6*decimal64Base).bits, "6"),
+	new64str(newFromPartsRaw(0, -15, 7*decimal64Base).bits, "7"),
+	new64str(newFromPartsRaw(0, -15, 8*decimal64Base).bits, "8"),
+	new64str(newFromPartsRaw(0, -15, 9*decimal64Base).bits, "9"),
 
-	newFromPartsStr(0, -14, 1*decimal64Base, "10"),
+	new64str(newFromPartsRaw(0, -14, 1*decimal64Base).bits, "10"),
 }
 
 var small64Strings = map[uint64]string{
@@ -256,10 +256,6 @@ func countTrailingZeros(n uint64) int {
 		zeros++
 	}
 	return zeros
-}
-
-func newFromPartsStr(sign int, exp int, significand uint64, s string) Decimal64 {
-	return new64str(newFromPartsRaw(sign, exp, significand).bits, s)
 }
 
 func newFromParts(sign int, exp int, significand uint64) Decimal64 {

--- a/decimal64.go
+++ b/decimal64.go
@@ -108,56 +108,56 @@ func (ctx Rounding) round(significand uint64, rndStatus discardedDigit) uint64 {
 var ErrNaN64 error = Error("sNaN64")
 
 var small64s = []Decimal64{
-	newFromPartsRaw(1, -14, 1*decimal64Base),
+	newFromPartsStr(1, -14, 1*decimal64Base, "-10"),
 
-	newFromPartsRaw(1, -15, 9*decimal64Base),
-	newFromPartsRaw(1, -15, 8*decimal64Base),
-	newFromPartsRaw(1, -15, 7*decimal64Base),
-	newFromPartsRaw(1, -15, 6*decimal64Base),
-	newFromPartsRaw(1, -15, 5*decimal64Base),
-	newFromPartsRaw(1, -15, 4*decimal64Base),
-	newFromPartsRaw(1, -15, 3*decimal64Base),
-	newFromPartsRaw(1, -15, 2*decimal64Base),
-	newFromPartsRaw(1, -15, 1*decimal64Base),
+	newFromPartsStr(1, -15, 9*decimal64Base, "-9"),
+	newFromPartsStr(1, -15, 8*decimal64Base, "-8"),
+	newFromPartsStr(1, -15, 7*decimal64Base, "-7"),
+	newFromPartsStr(1, -15, 6*decimal64Base, "-6"),
+	newFromPartsStr(1, -15, 5*decimal64Base, "-5"),
+	newFromPartsStr(1, -15, 4*decimal64Base, "-4"),
+	newFromPartsStr(1, -15, 3*decimal64Base, "-3"),
+	newFromPartsStr(1, -15, 2*decimal64Base, "-2"),
+	newFromPartsStr(1, -15, 1*decimal64Base, "-1"),
 
 	// TODO: Decimal64{}?
-	newFromPartsRaw(0, 0, 0),
+	newFromPartsStr(0, 0, 0, "0"),
 
-	newFromPartsRaw(0, -15, 1*decimal64Base),
-	newFromPartsRaw(0, -15, 2*decimal64Base),
-	newFromPartsRaw(0, -15, 3*decimal64Base),
-	newFromPartsRaw(0, -15, 4*decimal64Base),
-	newFromPartsRaw(0, -15, 5*decimal64Base),
-	newFromPartsRaw(0, -15, 6*decimal64Base),
-	newFromPartsRaw(0, -15, 7*decimal64Base),
-	newFromPartsRaw(0, -15, 8*decimal64Base),
-	newFromPartsRaw(0, -15, 9*decimal64Base),
+	newFromPartsStr(0, -15, 1*decimal64Base, "1"),
+	newFromPartsStr(0, -15, 2*decimal64Base, "2"),
+	newFromPartsStr(0, -15, 3*decimal64Base, "3"),
+	newFromPartsStr(0, -15, 4*decimal64Base, "4"),
+	newFromPartsStr(0, -15, 5*decimal64Base, "5"),
+	newFromPartsStr(0, -15, 6*decimal64Base, "6"),
+	newFromPartsStr(0, -15, 7*decimal64Base, "7"),
+	newFromPartsStr(0, -15, 8*decimal64Base, "8"),
+	newFromPartsStr(0, -15, 9*decimal64Base, "9"),
 
-	newFromPartsRaw(0, -14, 1*decimal64Base),
+	newFromPartsStr(0, -14, 1*decimal64Base, "10"),
 }
 
-var small64Strings = map[Decimal64]string{
-	small64s[0]:  "-10",
-	small64s[1]:  "-9",
-	small64s[2]:  "-8",
-	small64s[3]:  "-7",
-	small64s[4]:  "-6",
-	small64s[5]:  "-5",
-	small64s[6]:  "-4",
-	small64s[7]:  "-3",
-	small64s[8]:  "-2",
-	small64s[9]:  "-1",
-	small64s[10]: "0",
-	small64s[11]: "1",
-	small64s[12]: "2",
-	small64s[13]: "3",
-	small64s[14]: "4",
-	small64s[15]: "5",
-	small64s[16]: "6",
-	small64s[17]: "7",
-	small64s[18]: "8",
-	small64s[19]: "9",
-	small64s[20]: "10",
+var small64Strings = map[uint64]string{
+	small64s[0].bits:  "-10",
+	small64s[1].bits:  "-9",
+	small64s[2].bits:  "-8",
+	small64s[3].bits:  "-7",
+	small64s[4].bits:  "-6",
+	small64s[5].bits:  "-5",
+	small64s[6].bits:  "-4",
+	small64s[7].bits:  "-3",
+	small64s[8].bits:  "-2",
+	small64s[9].bits:  "-1",
+	small64s[10].bits: "0",
+	small64s[11].bits: "1",
+	small64s[12].bits: "2",
+	small64s[13].bits: "3",
+	small64s[14].bits: "4",
+	small64s[15].bits: "5",
+	small64s[16].bits: "6",
+	small64s[17].bits: "7",
+	small64s[18].bits: "8",
+	small64s[19].bits: "9",
+	small64s[20].bits: "10",
 }
 
 // New64FromInt64 returns a new Decimal64 with the given value.
@@ -258,8 +258,8 @@ func countTrailingZeros(n uint64) int {
 	return zeros
 }
 
-func new64Raw(bits uint64) Decimal64 {
-	return Decimal64{bits: bits}
+func newFromPartsStr(sign int, exp int, significand uint64, s string) Decimal64 {
+	return new64str(newFromPartsRaw(sign, exp, significand).bits, s)
 }
 
 func newFromParts(sign int, exp int, significand uint64) Decimal64 {
@@ -272,12 +272,12 @@ func newFromPartsRaw(sign int, exp int, significand uint64) Decimal64 {
 	if significand < 0x8<<50 {
 		// s EEeeeeeeee   (0)ttt tttttttttt tttttttttt tttttttttt tttttttttt tttttttttt
 		//   EE ∈ {00, 01, 10}
-		return new64Raw(s | uint64(exp+expOffset)<<(63-10) | significand)
+		return Decimal64{bits: s | uint64(exp+expOffset)<<(63-10) | significand}
 	}
 	// s 11EEeeeeeeee (100)t tttttttttt tttttttttt tttttttttt tttttttttt tttttttttt
 	//     EE ∈ {00, 01, 10}
 	significand &= 0x8<<50 - 1
-	return new64Raw(s | uint64(0xc00|(exp+expOffset))<<(63-12) | significand)
+	return Decimal64{bits: s | uint64(0xc00|(exp+expOffset))<<(63-12) | significand}
 }
 
 func (d Decimal64) parts() (fl flavor, sign int, exp int, significand uint64) {

--- a/decimal64.go
+++ b/decimal64.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"math/bits"
+	"strconv"
 )
 
 type discardedDigit int
@@ -136,29 +137,13 @@ var small64s = []Decimal64{
 	new64str(newFromPartsRaw(0, -14, 1*decimal64Base).bits, "10"),
 }
 
-var small64Strings = map[uint64]string{
-	small64s[0].bits:  "-10",
-	small64s[1].bits:  "-9",
-	small64s[2].bits:  "-8",
-	small64s[3].bits:  "-7",
-	small64s[4].bits:  "-6",
-	small64s[5].bits:  "-5",
-	small64s[6].bits:  "-4",
-	small64s[7].bits:  "-3",
-	small64s[8].bits:  "-2",
-	small64s[9].bits:  "-1",
-	small64s[10].bits: "0",
-	small64s[11].bits: "1",
-	small64s[12].bits: "2",
-	small64s[13].bits: "3",
-	small64s[14].bits: "4",
-	small64s[15].bits: "5",
-	small64s[16].bits: "6",
-	small64s[17].bits: "7",
-	small64s[18].bits: "8",
-	small64s[19].bits: "9",
-	small64s[20].bits: "10",
-}
+var small64Strings = func() map[uint64]string {
+	m := make(map[uint64]string, len(small64s))
+	for i := -10; i <= 10; i++ {
+		m[small64s[10+i].bits] = strconv.Itoa(i)
+	}
+	return m
+}()
 
 // New64FromInt64 returns a new Decimal64 with the given value.
 func New64FromInt64(i int64) Decimal64 {

--- a/decimal64_debug.go
+++ b/decimal64_debug.go
@@ -17,15 +17,23 @@ type Decimal64 struct {
 	bits        uint64
 }
 
-// This should be the only point at which Decimal64 instances are constructed raw.
-// The verbose construction below makes it easy to audit accidental raw cosntruction.
-// A search for (?<!\[\])Decimal64\{ must come up empty.
 func new64(bits uint64) Decimal64 {
-	d := new64Raw(bits)
+	d := new64nostr(bits)
+	d.s = d.String()
+	return d
+}
+
+func new64str(bits uint64, s string) Decimal64 {
+	d := new64nostr(bits)
+	d.s = s
+	return d
+}
+
+func new64nostr(bits uint64) Decimal64 {
+	d := Decimal64{bits: bits}
 
 	fl, sign, exp, significand := d.parts()
 
-	d.s = d.String()
 	d.fl = fl
 	d.sign = sign
 	d.exp = exp

--- a/decimal64_ndebug.go
+++ b/decimal64_ndebug.go
@@ -10,11 +10,16 @@ type Decimal64 struct {
 	bits uint64
 }
 
-// This should be the only point at which Decimal64 instances are constructed raw.
-// The verbose construction below makes it easy to audit accidental raw cosntruction.
-// A search for (?<!\[\])Decimal64\{ must come up empty.
 func new64(bits uint64) Decimal64 {
-	return new64Raw(bits)
+	return new64nostr(bits)
+}
+
+func new64str(bits uint64, _ string) Decimal64 {
+	return Decimal64{bits: bits}
+}
+
+func new64nostr(bits uint64) Decimal64 {
+	return Decimal64{bits: bits}
 }
 
 func checkSignificandIsNormal(significand uint64) {}

--- a/decimal64_ndebug.go
+++ b/decimal64_ndebug.go
@@ -11,7 +11,7 @@ type Decimal64 struct {
 }
 
 func new64(bits uint64) Decimal64 {
-	return new64nostr(bits)
+	return Decimal64{bits: bits}
 }
 
 func new64str(bits uint64, _ string) Decimal64 {

--- a/decimal64const_test.go
+++ b/decimal64const_test.go
@@ -1,15 +1,15 @@
 package decimal
 
-import (
-	"testing"
-
-	"github.com/stretchr/testify/require"
-)
+import "testing"
 
 func TestPi64(t *testing.T) {
-	require.Equal(t, "3.141592653589793", Pi64.String())
+	t.Parallel()
+
+	equal(t, "3.141592653589793", Pi64.String())
 }
 
 func TestE64(t *testing.T) {
-	require.Equal(t, "2.718281828459045", E64.String())
+	t.Parallel()
+
+	equal(t, "2.718281828459045", E64.String())
 }

--- a/decimal64decParts_test.go
+++ b/decimal64decParts_test.go
@@ -1,41 +1,40 @@
 package decimal
 
-import (
-	"testing"
-
-	"github.com/stretchr/testify/require"
-)
+import "testing"
 
 func TestPartsInf(t *testing.T) {
+	t.Parallel()
+
 	var a decParts
 	a.unpack(Infinity64)
-	require.True(t, a.isInf())
+	check(t, a.isInf())
 
 	a.unpack(NegInfinity64)
-	require.True(t, a.isInf())
+	check(t, a.isInf())
 }
 
 func TestIsNaN(t *testing.T) {
-	require := require.New(t)
+	t.Parallel()
+
 	var a decParts
 	a.unpack(Zero64)
-	require.Equal(false, a.isNaN())
+	check(t, !a.isNaN())
 
 	a.unpack(SNaN64)
-	require.Equal(true, a.isSNaN())
+	check(t, a.isSNaN())
 }
 
 func TestPartsSubnormal(t *testing.T) {
-	require := require.New(t)
+	t.Parallel()
 
 	d := MustParse64("0.1E-383")
 	var subnormal64Parts decParts
 	subnormal64Parts.unpack(d)
-	require.Equal(true, subnormal64Parts.isSubnormal())
+	check(t, subnormal64Parts.isSubnormal())
 
 	e := New64FromInt64(42)
 	var fortyTwoParts decParts
 	fortyTwoParts.unpack(e)
-	require.Equal(false, fortyTwoParts.isSubnormal())
+	check(t, !fortyTwoParts.isSubnormal())
 
 }

--- a/decimal64fmt.go
+++ b/decimal64fmt.go
@@ -96,7 +96,7 @@ func (d Decimal64) Append(buf []byte, format byte, prec int) []byte {
 }
 
 func precScale(prec int) Decimal64 {
-	return newFromPartsRaw(0, -15-max(0, prec), decimal64Base)
+	return new64(newFromPartsRaw(0, -15-max(0, prec), decimal64Base).bits)
 }
 
 // Append appends the text representation of d to buf.

--- a/decimal64fmt.go
+++ b/decimal64fmt.go
@@ -253,7 +253,7 @@ func (d Decimal64) String() string {
 }
 
 func (ctx Context64) str(d Decimal64) string {
-	if s, has := small64Strings[d]; has {
+	if s, has := small64Strings[d.bits]; has {
 		return s
 	}
 	return ctx.text(d, 'g', -1, -1)

--- a/decimal64gob_test.go
+++ b/decimal64gob_test.go
@@ -1,18 +1,14 @@
 package decimal
 
-import (
-	"testing"
-
-	"github.com/stretchr/testify/require"
-)
+import "testing"
 
 func TestDecimal64Gob(t *testing.T) {
-	require := require.New(t)
+	t.Parallel()
 
 	gob, err := New64FromInt64(23456).GobEncode()
-	require.NoError(err)
+	isnil(t, err)
 
 	var d Decimal64
-	require.NoError(d.GobDecode(gob))
-	require.Equal(New64FromInt64(23456), d)
+	isnil(t, d.GobDecode(gob))
+	equal(t, New64FromInt64(23456), d)
 }

--- a/decimal64json_test.go
+++ b/decimal64json_test.go
@@ -3,23 +3,27 @@ package decimal
 import (
 	"encoding/json"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestDecimal64MarshalJSON(t *testing.T) {
+	t.Parallel()
+
 	j, err := json.Marshal(MustParse64("123.432"))
-	require.NoError(t, err)
-	require.Equal(t, []byte("123.432"), j)
+	isnil(t, err)
+	equal(t, "123.432", string(j))
 }
 
 func TestDecimal64UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
 	var d Decimal64
-	require.NoError(t, json.Unmarshal([]byte("23456"), &d))
-	require.Equal(t, New64FromInt64(23456), d)
+	isnil(t, json.Unmarshal([]byte("23456"), &d))
+	equal(t, New64FromInt64(23456), d)
 }
 
 func TestDecimal64UnmarshalBadInputJSON(t *testing.T) {
+	t.Parallel()
+
 	var d Decimal64
-	require.Error(t, json.Unmarshal([]byte("omg"), &d))
+	notnil(t, json.Unmarshal([]byte("omg"), &d))
 }

--- a/decimal64marshal_test.go
+++ b/decimal64marshal_test.go
@@ -1,25 +1,26 @@
 package decimal
 
-import (
-	"testing"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-)
+import "testing"
 
 func TestDecimal64Marshal(t *testing.T) {
+	t.Parallel()
+
 	data, err := New64FromInt64(23456).MarshalText()
-	require.NoError(t, err)
-	assert.Equal(t, []byte("23456"), data)
+	isnil(t, err)
+	equal(t, "23456", string(data))
 }
 
 func TestDecimal64Unmarshal(t *testing.T) {
+	t.Parallel()
+
 	var d Decimal64
-	require.NoError(t, d.UnmarshalText([]byte("23456")))
-	assert.Equal(t, New64FromInt64(23456), d)
+	isnil(t, d.UnmarshalText([]byte("23456")))
+	equal(t, New64FromInt64(23456), d)
 }
 
 func TestDecimal64UnmarshalBadInput(t *testing.T) {
+	t.Parallel()
+
 	var d Decimal64
-	assert.Error(t, d.UnmarshalText([]byte("omg")))
+	notnil(t, d.UnmarshalText([]byte("omg")))
 }

--- a/decimal64math.go
+++ b/decimal64math.go
@@ -556,7 +556,7 @@ func (ctx Context64) roundRaw(d, e Decimal64) Decimal64 {
 
 var (
 	zero64Raw = newFromPartsRaw(0, 0, 0)
-	qNaN64Raw = new64Raw(0x7c << 56)
+	qNaN64Raw = new64nostr(0x7c << 56)
 )
 
 func (ctx Context64) roundRefRaw(dp, ep *decParts) Decimal64 {

--- a/decimal64math.go
+++ b/decimal64math.go
@@ -555,7 +555,7 @@ func (ctx Context64) roundRaw(d, e Decimal64) Decimal64 {
 }
 
 var (
-	zero64Raw = newFromPartsRaw(0, 0, 0)
+	zero64Raw = new64nostr(newFromPartsRaw(0, 0, 0).bits)
 	qNaN64Raw = new64nostr(0x7c << 56)
 )
 

--- a/decimal64math_test.go
+++ b/decimal64math_test.go
@@ -2,7 +2,7 @@ package decimal
 
 import (
 	"fmt"
-	"runtime"
+	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -128,8 +128,14 @@ func TestDecimal64MulThreeByOneTenthByTen(t *testing.T) {
 	decOne := New64FromInt64(1)
 	decOneTenth := decOne.Quo(decTen)
 	decProduct := decThree.Mul(decOneTenth).Mul(decTen)
-	r.Equal(decTen.Mul(decOneTenth), decOne)
-	r.Equal(decThree, decProduct)
+	requireEqualDecimal64(t, decTen.Mul(decOneTenth), decOne)
+	requireEqualDecimal64(t, decThree, decProduct)
+}
+
+func requireEqualDecimal64(t *testing.T, expected, actual Decimal64, fmtAndArgs ...any) {
+	t.Helper()
+	require := require.New(t)
+	require.Equal(expected.bits, actual.bits)
 }
 
 func TestDecimal64Mul(t *testing.T) {
@@ -197,7 +203,6 @@ func checkDecimal64QuoByF(t *testing.T, f int64) {
 				t.Log("q", q.bits, qFlavor, qSign, qExp, qSignificand)
 			}
 			if !assert.Equal(t, e, q, "%d / %d ≠ %v (expecting %v)", k, j, q, e) {
-				runtime.Breakpoint()
 				n.Quo(d)
 				t.FailNow()
 			}
@@ -275,7 +280,6 @@ func TestDecimal64QuoInf(t *testing.T) {
 }
 
 func TestDecimal64MulPo10(t *testing.T) {
-	r := require.New(t)
 	for i, u := range tenToThe128 {
 		for j, v := range tenToThe128 {
 			k := i + j
@@ -288,19 +292,18 @@ func TestDecimal64MulPo10(t *testing.T) {
 			}
 			e := New64FromInt64(int64(w.lo))
 			a := New64FromInt64(int64(u.lo)).Mul(New64FromInt64(int64(v.lo)))
-			r.EqualValues(e, a, "%v * %v ≠ %v (expecting %v)", u, v, a, e)
+			requireEqualDecimal64(t, e, a, "%v * %v ≠ %v (expecting %v)", u, v, a, e)
 		}
 	}
 }
 
 func TestDecimal64Sqrt(t *testing.T) {
-	r := require.New(t)
 	for i := int64(0); i < 100000000; i = i*19/17 + 1 {
 		i2 := i * i
 		e := New64FromInt64(i)
 		n := New64FromInt64(i2)
 		a := n.Sqrt()
-		r.EqualValues(e, a, "√%v != %v (expected %v)", n, a, e)
+		requireEqualDecimal64(t, e, a, "√%v != %v (expected %v)", n, a, e)
 	}
 }
 
@@ -515,7 +518,7 @@ func TestQuoOverflow(t *testing.T) {
 		n := MustParse64(num)
 		d := MustParse64(denom)
 		if !assert.Equal(t, expected, n.Quo(d)) {
-			runtime.Breakpoint()
+			log.Printf("TestQuoOverflow: num = %d", n)
 			n.Quo(d)
 		}
 	}

--- a/decimal64math_test.go
+++ b/decimal64math_test.go
@@ -4,9 +4,6 @@ import (
 	"fmt"
 	"log"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func checkDecimal64BinOp(
@@ -15,7 +12,6 @@ func checkDecimal64BinOp(
 	actual func(a, b Decimal64) Decimal64,
 	op string,
 ) {
-	r := require.New(t)
 	for i := int64(-100); i <= 100; i++ {
 		a := New64FromInt64(i)
 		for j := int64(-100); j <= 100; j++ {
@@ -23,25 +19,27 @@ func checkDecimal64BinOp(
 			c := actual(a, b)
 			k := c.Int64()
 			e := expected(i, j)
-			r.EqualValues(e, k, "%d %s %d ≠ %d (expecting %d)", i, op, j, k, e)
+			equal(t, e, k)
 		}
 	}
 }
 
 func TestDecimal64Abs(t *testing.T) {
-	require := require.New(t)
+	t.Parallel()
 
-	require.Equal(Zero64, Zero64.Abs())
-	require.Equal(Zero64, NegZero64.Abs())
-	require.Equal(Infinity64, Infinity64.Abs())
-	require.Equal(Infinity64, NegInfinity64.Abs())
+	equal(t, Zero64, Zero64.Abs())
+	equal(t, Zero64, NegZero64.Abs())
+	equal(t, Infinity64, Infinity64.Abs())
+	equal(t, Infinity64, NegInfinity64.Abs())
 
 	fortyTwo := New64FromInt64(42)
-	require.Equal(fortyTwo, fortyTwo.Abs())
-	require.Equal(fortyTwo, New64FromInt64(-42).Abs())
+	equal(t, fortyTwo, fortyTwo.Abs())
+	equal(t, fortyTwo, New64FromInt64(-42).Abs())
 }
 
 func TestDecimal64Add(t *testing.T) {
+	t.Parallel()
+
 	if testing.Short() {
 		t.Skip("skipping TestDecimal64Add in short mode.")
 	}
@@ -53,65 +51,65 @@ func TestDecimal64Add(t *testing.T) {
 }
 
 func TestDecimal64AddNaN(t *testing.T) {
-	require := require.New(t)
+	t.Parallel()
 
 	fortyTwo := New64FromInt64(42)
 
-	require.Equal(QNaN64, fortyTwo.Add(QNaN64))
-	require.Equal(QNaN64, QNaN64.Add(fortyTwo))
+	equal(t, QNaN64, fortyTwo.Add(QNaN64))
+	equal(t, QNaN64, QNaN64.Add(fortyTwo))
 }
 
 func TestDecimal64AddInf(t *testing.T) {
-	require := require.New(t)
+	t.Parallel()
 
 	fortyTwo := New64FromInt64(42)
 
-	require.Equal(Infinity64, fortyTwo.Add(Infinity64))
-	require.Equal(Infinity64, Infinity64.Add(fortyTwo))
+	equal(t, Infinity64, fortyTwo.Add(Infinity64))
+	equal(t, Infinity64, Infinity64.Add(fortyTwo))
 
-	require.Equal(NegInfinity64, fortyTwo.Add(NegInfinity64))
-	require.Equal(NegInfinity64, NegInfinity64.Add(fortyTwo))
+	equal(t, NegInfinity64, fortyTwo.Add(NegInfinity64))
+	equal(t, NegInfinity64, NegInfinity64.Add(fortyTwo))
 
-	require.Equal(Infinity64, Infinity64.Add(Infinity64))
-	require.Equal(NegInfinity64, NegInfinity64.Add(NegInfinity64))
+	equal(t, Infinity64, Infinity64.Add(Infinity64))
+	equal(t, NegInfinity64, NegInfinity64.Add(NegInfinity64))
 
-	require.Equal(QNaN64, Infinity64.Add(NegInfinity64))
-	require.Equal(QNaN64, NegInfinity64.Add(Infinity64))
+	equal(t, QNaN64, Infinity64.Add(NegInfinity64))
+	equal(t, QNaN64, NegInfinity64.Add(Infinity64))
 }
 
 func TestDecimal64Cmp(t *testing.T) {
-	require := require.New(t)
+	t.Parallel()
 
-	require.Equal(0, NegOne64.Cmp(NegOne64))
+	equal(t, 0, NegOne64.Cmp(NegOne64))
 
-	require.Equal(0, Zero64.Cmp(Zero64))
-	require.Equal(0, Zero64.Cmp(NegZero64))
-	require.Equal(0, NegZero64.Cmp(Zero64))
-	require.Equal(0, NegZero64.Cmp(NegZero64))
+	equal(t, 0, Zero64.Cmp(Zero64))
+	equal(t, 0, Zero64.Cmp(NegZero64))
+	equal(t, 0, NegZero64.Cmp(Zero64))
+	equal(t, 0, NegZero64.Cmp(NegZero64))
 
-	require.Equal(0, One64.Cmp(One64))
-	require.Equal(-1, NegOne64.Cmp(Zero64))
-	require.Equal(-1, NegOne64.Cmp(NegZero64))
-	require.Equal(-1, NegOne64.Cmp(One64))
-	require.Equal(-1, Zero64.Cmp(One64))
-	require.Equal(-1, NegZero64.Cmp(One64))
-	require.Equal(1, Zero64.Cmp(NegOne64))
-	require.Equal(1, NegZero64.Cmp(NegOne64))
-	require.Equal(1, One64.Cmp(NegOne64))
-	require.Equal(1, One64.Cmp(Zero64))
-	require.Equal(1, One64.Cmp(NegZero64))
+	equal(t, 0, One64.Cmp(One64))
+	equal(t, -1, NegOne64.Cmp(Zero64))
+	equal(t, -1, NegOne64.Cmp(NegZero64))
+	equal(t, -1, NegOne64.Cmp(One64))
+	equal(t, -1, Zero64.Cmp(One64))
+	equal(t, -1, NegZero64.Cmp(One64))
+	equal(t, 1, Zero64.Cmp(NegOne64))
+	equal(t, 1, NegZero64.Cmp(NegOne64))
+	equal(t, 1, One64.Cmp(NegOne64))
+	equal(t, 1, One64.Cmp(Zero64))
+	equal(t, 1, One64.Cmp(NegZero64))
 }
 
 func TestDecimal64CmpNaN(t *testing.T) {
-	require := require.New(t)
+	t.Parallel()
 
-	require.Equal(-2, QNaN64.Cmp(QNaN64))
-	require.Equal(-2, Zero64.Cmp(QNaN64))
-	require.Equal(-2, QNaN64.Cmp(Zero64))
+	equal(t, -2, QNaN64.Cmp(QNaN64))
+	equal(t, -2, Zero64.Cmp(QNaN64))
+	equal(t, -2, QNaN64.Cmp(Zero64))
 }
 
 func TestDecimal64MulThreeByOneTenthByTen(t *testing.T) {
-	r := require.New(t)
+	t.Parallel()
 
 	// float 3*0.1*10 ≠ 3
 	fltThree := 3.0
@@ -119,8 +117,8 @@ func TestDecimal64MulThreeByOneTenthByTen(t *testing.T) {
 	fltOne := 1.0
 	fltOneTenth := fltOne / fltTen
 	fltProduct := fltThree * fltOneTenth * fltTen
-	r.Equal(fltTen*fltOneTenth, fltOne)
-	r.NotEqual(fltThree, fltProduct)
+	equal(t, fltTen*fltOneTenth, fltOne)
+	notequal(t, fltThree, fltProduct)
 
 	// decimal 3*0.1*10 = 3
 	decThree := New64FromInt64(3)
@@ -128,17 +126,13 @@ func TestDecimal64MulThreeByOneTenthByTen(t *testing.T) {
 	decOne := New64FromInt64(1)
 	decOneTenth := decOne.Quo(decTen)
 	decProduct := decThree.Mul(decOneTenth).Mul(decTen)
-	requireEqualDecimal64(t, decTen.Mul(decOneTenth), decOne)
-	requireEqualDecimal64(t, decThree, decProduct)
-}
-
-func requireEqualDecimal64(t *testing.T, expected, actual Decimal64, fmtAndArgs ...any) {
-	t.Helper()
-	require := require.New(t)
-	require.Equal(expected.bits, actual.bits)
+	equalD64(t, decTen.Mul(decOneTenth), decOne)
+	equalD64(t, decThree, decProduct)
 }
 
 func TestDecimal64Mul(t *testing.T) {
+	t.Parallel()
+
 	if testing.Short() {
 		t.Skip("skipping TestDecimal64Mul in short mode.")
 	}
@@ -150,34 +144,34 @@ func TestDecimal64Mul(t *testing.T) {
 }
 
 func TestDecimal64MulNaN(t *testing.T) {
-	require := require.New(t)
+	t.Parallel()
 
 	fortyTwo := New64FromInt64(42)
 
-	require.Equal(QNaN64, fortyTwo.Mul(QNaN64))
-	require.Equal(QNaN64, QNaN64.Mul(fortyTwo))
+	equal(t, QNaN64, fortyTwo.Mul(QNaN64))
+	equal(t, QNaN64, QNaN64.Mul(fortyTwo))
 }
 
 func TestDecimal64MulInf(t *testing.T) {
-	require := require.New(t)
+	t.Parallel()
 
 	fortyTwo := New64FromInt64(42)
 	negFortyTwo := New64FromInt64(-42)
 
-	require.Equal(Infinity64, fortyTwo.Mul(Infinity64))
-	require.Equal(Infinity64, Infinity64.Mul(fortyTwo))
-	require.Equal(NegInfinity64, negFortyTwo.Mul(Infinity64))
-	require.Equal(NegInfinity64, Infinity64.Mul(negFortyTwo))
+	equal(t, Infinity64, fortyTwo.Mul(Infinity64))
+	equal(t, Infinity64, Infinity64.Mul(fortyTwo))
+	equal(t, NegInfinity64, negFortyTwo.Mul(Infinity64))
+	equal(t, NegInfinity64, Infinity64.Mul(negFortyTwo))
 
-	require.Equal(NegInfinity64, fortyTwo.Mul(NegInfinity64))
-	require.Equal(NegInfinity64, NegInfinity64.Mul(fortyTwo))
-	require.Equal(Infinity64, negFortyTwo.Mul(NegInfinity64))
-	require.Equal(Infinity64, NegInfinity64.Mul(negFortyTwo))
+	equal(t, NegInfinity64, fortyTwo.Mul(NegInfinity64))
+	equal(t, NegInfinity64, NegInfinity64.Mul(fortyTwo))
+	equal(t, Infinity64, negFortyTwo.Mul(NegInfinity64))
+	equal(t, Infinity64, NegInfinity64.Mul(negFortyTwo))
 
-	require.Equal(Infinity64, Infinity64.Mul(Infinity64))
-	require.Equal(Infinity64, NegInfinity64.Mul(NegInfinity64))
-	require.Equal(NegInfinity64, Infinity64.Mul(NegInfinity64))
-	require.Equal(NegInfinity64, NegInfinity64.Mul(Infinity64))
+	equal(t, Infinity64, Infinity64.Mul(Infinity64))
+	equal(t, Infinity64, NegInfinity64.Mul(NegInfinity64))
+	equal(t, NegInfinity64, Infinity64.Mul(NegInfinity64))
+	equal(t, NegInfinity64, NegInfinity64.Mul(Infinity64))
 }
 
 func checkDecimal64QuoByF(t *testing.T, f int64) {
@@ -202,7 +196,7 @@ func checkDecimal64QuoByF(t *testing.T, f int64) {
 				t.Log("e", e.bits, eFlavor, eSign, eExp, eSignificand)
 				t.Log("q", q.bits, qFlavor, qSign, qExp, qSignificand)
 			}
-			if !assert.Equal(t, e, q, "%d / %d ≠ %v (expecting %v)", k, j, q, e) {
+			if !equal(t, e, q) {
 				n.Quo(d)
 				t.FailNow()
 			}
@@ -242,44 +236,46 @@ func TestDecimal64Scale(t *testing.T) {
 				continue
 			}
 			actual := x.Quo(y).Text('e', -1)
-			require.Equal(t, expected, actual, "i = %v, j = %v", i, j)
+			equal(t, expected, actual)
 		}
 	}
 }
 
 func TestDecimal64QuoNaN(t *testing.T) {
-	require := require.New(t)
+	t.Parallel()
 
 	fortyTwo := New64FromInt64(42)
 
-	require.Equal(QNaN64, fortyTwo.Quo(QNaN64))
-	require.Equal(QNaN64, QNaN64.Quo(fortyTwo))
+	equal(t, QNaN64, fortyTwo.Quo(QNaN64))
+	equal(t, QNaN64, QNaN64.Quo(fortyTwo))
 
 }
 
 func TestDecimal64QuoInf(t *testing.T) {
-	require := require.New(t)
+	t.Parallel()
 
 	fortyTwo := New64FromInt64(42)
 	negFortyTwo := New64FromInt64(-42)
 
-	require.Equal(Zero64, fortyTwo.Quo(Infinity64))
-	require.Equal(Infinity64, Infinity64.Quo(fortyTwo))
-	require.Equal(NegZero64, negFortyTwo.Quo(Infinity64))
-	require.Equal(NegInfinity64, Infinity64.Quo(negFortyTwo))
+	equal(t, Zero64, fortyTwo.Quo(Infinity64))
+	equal(t, Infinity64, Infinity64.Quo(fortyTwo))
+	equal(t, NegZero64, negFortyTwo.Quo(Infinity64))
+	equal(t, NegInfinity64, Infinity64.Quo(negFortyTwo))
 
-	require.Equal(NegZero64, fortyTwo.Quo(NegInfinity64))
-	require.Equal(NegInfinity64, NegInfinity64.Quo(fortyTwo))
-	require.Equal(Zero64, negFortyTwo.Quo(NegInfinity64))
-	require.Equal(Infinity64, NegInfinity64.Quo(negFortyTwo))
+	equal(t, NegZero64, fortyTwo.Quo(NegInfinity64))
+	equal(t, NegInfinity64, NegInfinity64.Quo(fortyTwo))
+	equal(t, Zero64, negFortyTwo.Quo(NegInfinity64))
+	equal(t, Infinity64, NegInfinity64.Quo(negFortyTwo))
 
-	require.Equal(QNaN64, Infinity64.Quo(Infinity64))
-	require.Equal(QNaN64, NegInfinity64.Quo(NegInfinity64))
-	require.Equal(QNaN64, Infinity64.Quo(NegInfinity64))
-	require.Equal(QNaN64, NegInfinity64.Quo(Infinity64))
+	equal(t, QNaN64, Infinity64.Quo(Infinity64))
+	equal(t, QNaN64, NegInfinity64.Quo(NegInfinity64))
+	equal(t, QNaN64, Infinity64.Quo(NegInfinity64))
+	equal(t, QNaN64, NegInfinity64.Quo(Infinity64))
 }
 
 func TestDecimal64MulPo10(t *testing.T) {
+	t.Parallel()
+
 	for i, u := range tenToThe128 {
 		for j, v := range tenToThe128 {
 			k := i + j
@@ -292,38 +288,45 @@ func TestDecimal64MulPo10(t *testing.T) {
 			}
 			e := New64FromInt64(int64(w.lo))
 			a := New64FromInt64(int64(u.lo)).Mul(New64FromInt64(int64(v.lo)))
-			requireEqualDecimal64(t, e, a, "%v * %v ≠ %v (expecting %v)", u, v, a, e)
+			equalD64(t, e, a, "%v * %v ≠ %v (expecting %v)", u, v, a, e)
 		}
 	}
 }
 
 func TestDecimal64Sqrt(t *testing.T) {
+	t.Parallel()
+
 	for i := int64(0); i < 100000000; i = i*19/17 + 1 {
 		i2 := i * i
 		e := New64FromInt64(i)
 		n := New64FromInt64(i2)
 		a := n.Sqrt()
-		requireEqualDecimal64(t, e, a, "√%v != %v (expected %v)", n, a, e)
+		equalD64(t, e, a, "√%v != %v (expected %v)", n, a, e)
 	}
 }
 
 func TestDecimal64SqrtNeg(t *testing.T) {
-	require.EqualValues(t, QNaN64, New64FromInt64(-1).Sqrt())
+	t.Parallel()
+
+	equal(t, QNaN64, New64FromInt64(-1).Sqrt())
 }
 
 func TestDecimal64SqrtNaN(t *testing.T) {
-	require := require.New(t)
-	require.Equal(QNaN64, QNaN64.Sqrt())
+	t.Parallel()
+
+	equal(t, QNaN64, QNaN64.Sqrt())
 }
 
 func TestDecimal64SqrtInf(t *testing.T) {
-	require := require.New(t)
+	t.Parallel()
 
-	require.Equal(Infinity64, Infinity64.Sqrt())
-	require.Equal(QNaN64, NegInfinity64.Sqrt())
+	equal(t, Infinity64, Infinity64.Sqrt())
+	equal(t, QNaN64, NegInfinity64.Sqrt())
 }
 
 func TestDecimal64Sub(t *testing.T) {
+	t.Parallel()
+
 	checkDecimal64BinOp(t,
 		func(a, b int64) int64 { return a - b },
 		func(a, b Decimal64) Decimal64 { return a.Sub(b) },
@@ -340,99 +343,99 @@ func TestRoundHalfUp(t *testing.T) {
 	t.Parallel()
 
 	ctx := Context64{Rounding: HalfUp}
-	assert.Equal(t, uint64(10), rnd(ctx, 10, 1))
-	assert.Equal(t, uint64(10), rnd(ctx, 11, 1))
-	assert.Equal(t, uint64(20), rnd(ctx, 15, 1))
-	assert.Equal(t, uint64(20), rnd(ctx, 19, 1))
-	assert.Equal(t, uint64(200), rnd(ctx, 249, 10))
-	assert.Equal(t, uint64(300), rnd(ctx, 250, 10))
-	assert.Equal(t, uint64(300), rnd(ctx, 251, 10))
-	assert.Equal(t, uint64(300), rnd(ctx, 299, 10))
-	assert.Equal(t, uint64(300), rnd(ctx, 300, 10))
-	assert.Equal(t, uint64(1000000000000000), rnd(ctx, 1000000000000000, 100000000000000))
-	assert.Equal(t, uint64(1000000000000000), rnd(ctx, 1100000000000000, 100000000000000))
-	assert.Equal(t, uint64(1000000000000000), rnd(ctx, 1499999999999999, 100000000000000))
-	assert.Equal(t, uint64(2000000000000000), rnd(ctx, 1500000000000000, 100000000000000))
-	assert.Equal(t, uint64(2000000000000000), rnd(ctx, 1500000000000001, 100000000000000))
-	assert.Equal(t, uint64(2000000000000000), rnd(ctx, 1900000000000000, 100000000000000))
-	assert.Equal(t, uint64(2000000000000000), rnd(ctx, 1999999999999999, 100000000000000))
-	assert.Equal(t, uint64(2000000000000000), rnd(ctx, 2000000000000000, 100000000000000))
-	assert.Equal(t, uint64(2000000000000000), rnd(ctx, 2499999999999999, 100000000000000))
-	assert.Equal(t, uint64(3000000000000000), rnd(ctx, 2500000000000000, 100000000000000))
-	assert.Equal(t, uint64(3000000000000000), rnd(ctx, 2500000000000001, 100000000000000))
-	assert.Equal(t, uint64(3000000000000000), rnd(ctx, 2999999999999999, 100000000000000))
-	assert.Equal(t, uint64(3000000000000000), rnd(ctx, 3000000000000000, 100000000000000))
+	equal(t, uint64(10), rnd(ctx, 10, 1))
+	equal(t, uint64(10), rnd(ctx, 11, 1))
+	equal(t, uint64(20), rnd(ctx, 15, 1))
+	equal(t, uint64(20), rnd(ctx, 19, 1))
+	equal(t, uint64(200), rnd(ctx, 249, 10))
+	equal(t, uint64(300), rnd(ctx, 250, 10))
+	equal(t, uint64(300), rnd(ctx, 251, 10))
+	equal(t, uint64(300), rnd(ctx, 299, 10))
+	equal(t, uint64(300), rnd(ctx, 300, 10))
+	equal(t, uint64(1000000000000000), rnd(ctx, 1000000000000000, 100000000000000))
+	equal(t, uint64(1000000000000000), rnd(ctx, 1100000000000000, 100000000000000))
+	equal(t, uint64(1000000000000000), rnd(ctx, 1499999999999999, 100000000000000))
+	equal(t, uint64(2000000000000000), rnd(ctx, 1500000000000000, 100000000000000))
+	equal(t, uint64(2000000000000000), rnd(ctx, 1500000000000001, 100000000000000))
+	equal(t, uint64(2000000000000000), rnd(ctx, 1900000000000000, 100000000000000))
+	equal(t, uint64(2000000000000000), rnd(ctx, 1999999999999999, 100000000000000))
+	equal(t, uint64(2000000000000000), rnd(ctx, 2000000000000000, 100000000000000))
+	equal(t, uint64(2000000000000000), rnd(ctx, 2499999999999999, 100000000000000))
+	equal(t, uint64(3000000000000000), rnd(ctx, 2500000000000000, 100000000000000))
+	equal(t, uint64(3000000000000000), rnd(ctx, 2500000000000001, 100000000000000))
+	equal(t, uint64(3000000000000000), rnd(ctx, 2999999999999999, 100000000000000))
+	equal(t, uint64(3000000000000000), rnd(ctx, 3000000000000000, 100000000000000))
 }
 
 func TestRoundHalfEven(t *testing.T) {
 	t.Parallel()
 
 	ctx := Context64{Rounding: HalfEven}
-	assert.Equal(t, uint64(10), rnd(ctx, 10, 1))
-	assert.Equal(t, uint64(10), rnd(ctx, 11, 1))
-	assert.Equal(t, uint64(20), rnd(ctx, 15, 1))
-	assert.Equal(t, uint64(20), rnd(ctx, 19, 1))
-	assert.Equal(t, uint64(200), rnd(ctx, 249, 10))
-	assert.Equal(t, uint64(200), rnd(ctx, 250, 10))
-	assert.Equal(t, uint64(300), rnd(ctx, 251, 10))
-	assert.Equal(t, uint64(300), rnd(ctx, 299, 10))
-	assert.Equal(t, uint64(300), rnd(ctx, 300, 10))
-	assert.Equal(t, uint64(1000000000000000), rnd(ctx, 1000000000000000, 100000000000000))
-	assert.Equal(t, uint64(1000000000000000), rnd(ctx, 1100000000000000, 100000000000000))
-	assert.Equal(t, uint64(1000000000000000), rnd(ctx, 1499999999999999, 100000000000000))
-	assert.Equal(t, uint64(2000000000000000), rnd(ctx, 1500000000000000, 100000000000000))
-	assert.Equal(t, uint64(2000000000000000), rnd(ctx, 1500000000000001, 100000000000000))
-	assert.Equal(t, uint64(2000000000000000), rnd(ctx, 1900000000000000, 100000000000000))
-	assert.Equal(t, uint64(2000000000000000), rnd(ctx, 1999999999999999, 100000000000000))
-	assert.Equal(t, uint64(2000000000000000), rnd(ctx, 2000000000000000, 100000000000000))
-	assert.Equal(t, uint64(2000000000000000), rnd(ctx, 2499999999999999, 100000000000000))
-	assert.Equal(t, uint64(2000000000000000), rnd(ctx, 2500000000000000, 100000000000000))
-	assert.Equal(t, uint64(3000000000000000), rnd(ctx, 2500000000000001, 100000000000000))
-	assert.Equal(t, uint64(3000000000000000), rnd(ctx, 2999999999999999, 100000000000000))
-	assert.Equal(t, uint64(3000000000000000), rnd(ctx, 3000000000000000, 100000000000000))
+	equal(t, uint64(10), rnd(ctx, 10, 1))
+	equal(t, uint64(10), rnd(ctx, 11, 1))
+	equal(t, uint64(20), rnd(ctx, 15, 1))
+	equal(t, uint64(20), rnd(ctx, 19, 1))
+	equal(t, uint64(200), rnd(ctx, 249, 10))
+	equal(t, uint64(200), rnd(ctx, 250, 10))
+	equal(t, uint64(300), rnd(ctx, 251, 10))
+	equal(t, uint64(300), rnd(ctx, 299, 10))
+	equal(t, uint64(300), rnd(ctx, 300, 10))
+	equal(t, uint64(1000000000000000), rnd(ctx, 1000000000000000, 100000000000000))
+	equal(t, uint64(1000000000000000), rnd(ctx, 1100000000000000, 100000000000000))
+	equal(t, uint64(1000000000000000), rnd(ctx, 1499999999999999, 100000000000000))
+	equal(t, uint64(2000000000000000), rnd(ctx, 1500000000000000, 100000000000000))
+	equal(t, uint64(2000000000000000), rnd(ctx, 1500000000000001, 100000000000000))
+	equal(t, uint64(2000000000000000), rnd(ctx, 1900000000000000, 100000000000000))
+	equal(t, uint64(2000000000000000), rnd(ctx, 1999999999999999, 100000000000000))
+	equal(t, uint64(2000000000000000), rnd(ctx, 2000000000000000, 100000000000000))
+	equal(t, uint64(2000000000000000), rnd(ctx, 2499999999999999, 100000000000000))
+	equal(t, uint64(2000000000000000), rnd(ctx, 2500000000000000, 100000000000000))
+	equal(t, uint64(3000000000000000), rnd(ctx, 2500000000000001, 100000000000000))
+	equal(t, uint64(3000000000000000), rnd(ctx, 2999999999999999, 100000000000000))
+	equal(t, uint64(3000000000000000), rnd(ctx, 3000000000000000, 100000000000000))
 }
 
 func TestRoundHDown(t *testing.T) {
 	t.Parallel()
 
 	ctx := Context64{Rounding: Down}
-	assert.Equal(t, uint64(10), rnd(ctx, 10, 1))
-	assert.Equal(t, uint64(10), rnd(ctx, 11, 1))
-	assert.Equal(t, uint64(10), rnd(ctx, 15, 1))
-	assert.Equal(t, uint64(10), rnd(ctx, 19, 1))
-	assert.Equal(t, uint64(200), rnd(ctx, 249, 10))
-	assert.Equal(t, uint64(200), rnd(ctx, 250, 10))
-	assert.Equal(t, uint64(200), rnd(ctx, 251, 10))
-	assert.Equal(t, uint64(200), rnd(ctx, 299, 10))
-	assert.Equal(t, uint64(300), rnd(ctx, 300, 10))
-	assert.Equal(t, uint64(1000000000000000), rnd(ctx, 1000000000000000, 100000000000000))
-	assert.Equal(t, uint64(1000000000000000), rnd(ctx, 1100000000000000, 100000000000000))
-	assert.Equal(t, uint64(1000000000000000), rnd(ctx, 1499999999999999, 100000000000000))
-	assert.Equal(t, uint64(1000000000000000), rnd(ctx, 1500000000000000, 100000000000000))
-	assert.Equal(t, uint64(1000000000000000), rnd(ctx, 1500000000000001, 100000000000000))
-	assert.Equal(t, uint64(1000000000000000), rnd(ctx, 1900000000000000, 100000000000000))
-	assert.Equal(t, uint64(1000000000000000), rnd(ctx, 1999999999999999, 100000000000000))
-	assert.Equal(t, uint64(2000000000000000), rnd(ctx, 2000000000000000, 100000000000000))
-	assert.Equal(t, uint64(2000000000000000), rnd(ctx, 2499999999999999, 100000000000000))
-	assert.Equal(t, uint64(2000000000000000), rnd(ctx, 2500000000000000, 100000000000000))
-	assert.Equal(t, uint64(2000000000000000), rnd(ctx, 2500000000000001, 100000000000000))
-	assert.Equal(t, uint64(2000000000000000), rnd(ctx, 2999999999999999, 100000000000000))
-	assert.Equal(t, uint64(3000000000000000), rnd(ctx, 3000000000000000, 100000000000000))
+	equal(t, uint64(10), rnd(ctx, 10, 1))
+	equal(t, uint64(10), rnd(ctx, 11, 1))
+	equal(t, uint64(10), rnd(ctx, 15, 1))
+	equal(t, uint64(10), rnd(ctx, 19, 1))
+	equal(t, uint64(200), rnd(ctx, 249, 10))
+	equal(t, uint64(200), rnd(ctx, 250, 10))
+	equal(t, uint64(200), rnd(ctx, 251, 10))
+	equal(t, uint64(200), rnd(ctx, 299, 10))
+	equal(t, uint64(300), rnd(ctx, 300, 10))
+	equal(t, uint64(1000000000000000), rnd(ctx, 1000000000000000, 100000000000000))
+	equal(t, uint64(1000000000000000), rnd(ctx, 1100000000000000, 100000000000000))
+	equal(t, uint64(1000000000000000), rnd(ctx, 1499999999999999, 100000000000000))
+	equal(t, uint64(1000000000000000), rnd(ctx, 1500000000000000, 100000000000000))
+	equal(t, uint64(1000000000000000), rnd(ctx, 1500000000000001, 100000000000000))
+	equal(t, uint64(1000000000000000), rnd(ctx, 1900000000000000, 100000000000000))
+	equal(t, uint64(1000000000000000), rnd(ctx, 1999999999999999, 100000000000000))
+	equal(t, uint64(2000000000000000), rnd(ctx, 2000000000000000, 100000000000000))
+	equal(t, uint64(2000000000000000), rnd(ctx, 2499999999999999, 100000000000000))
+	equal(t, uint64(2000000000000000), rnd(ctx, 2500000000000000, 100000000000000))
+	equal(t, uint64(2000000000000000), rnd(ctx, 2500000000000001, 100000000000000))
+	equal(t, uint64(2000000000000000), rnd(ctx, 2999999999999999, 100000000000000))
+	equal(t, uint64(3000000000000000), rnd(ctx, 3000000000000000, 100000000000000))
 }
 
 func TestToIntegral(t *testing.T) {
 	t.Parallel()
 
 	ctx := Context64{Rounding: HalfUp}
-	assert.Equal(t, "0", ctx.ToIntegral(MustParse64("0")).String())
-	assert.Equal(t, "0", ctx.ToIntegral(MustParse64("0.499999999999999")).String())
-	assert.Equal(t, "1", ctx.ToIntegral(MustParse64("1")).String())
-	assert.Equal(t, "1", ctx.ToIntegral(MustParse64("1.49999999999999")).String())
-	assert.Equal(t, "2", ctx.ToIntegral(MustParse64("1.5")).String())
-	assert.Equal(t, "9", ctx.ToIntegral(MustParse64("9.49999999999999")).String())
-	assert.Equal(t, "10", ctx.ToIntegral(MustParse64("9.5")).String())
-	assert.Equal(t, "99", ctx.ToIntegral(MustParse64("99.499999999999")).String())
-	assert.Equal(t, "100", ctx.ToIntegral(MustParse64("99.5")).String())
+	equal(t, "0", ctx.ToIntegral(MustParse64("0")).String())
+	equal(t, "0", ctx.ToIntegral(MustParse64("0.499999999999999")).String())
+	equal(t, "1", ctx.ToIntegral(MustParse64("1")).String())
+	equal(t, "1", ctx.ToIntegral(MustParse64("1.49999999999999")).String())
+	equal(t, "2", ctx.ToIntegral(MustParse64("1.5")).String())
+	equal(t, "9", ctx.ToIntegral(MustParse64("9.49999999999999")).String())
+	equal(t, "10", ctx.ToIntegral(MustParse64("9.5")).String())
+	equal(t, "99", ctx.ToIntegral(MustParse64("99.499999999999")).String())
+	equal(t, "100", ctx.ToIntegral(MustParse64("99.5")).String())
 }
 
 func benchmarkDecimal64Data() []Decimal64 {
@@ -506,18 +509,21 @@ func BenchmarkDecimal64Sub(b *testing.B) {
 }
 
 func TestAddOverflow(t *testing.T) {
-	require := require.New(t)
-	require.Equal(NegInfinity64, NegMax64.Sub(MustParse64("0.00000000000001e384")))
-	require.Equal(Infinity64, Max64.Add(MustParse64("0.000000000000001e384")))
-	require.Equal(Max64, Max64.Add(MustParse64("1")))
-	require.Equal(Max64, Zero64.Add(Max64))
+	t.Parallel()
+
+	equal(t, NegInfinity64, NegMax64.Sub(MustParse64("0.00000000000001e384")))
+	equal(t, Infinity64, Max64.Add(MustParse64("0.000000000000001e384")))
+	equal(t, Max64, Max64.Add(MustParse64("1")))
+	equal(t, Max64, Zero64.Add(Max64))
 }
 
 func TestQuoOverflow(t *testing.T) {
+	t.Parallel()
+
 	test := func(expected Decimal64, num, denom string) {
 		n := MustParse64(num)
 		d := MustParse64(denom)
-		if !assert.Equal(t, expected, n.Quo(d)) {
+		if !equal(t, expected, n.Quo(d)) {
 			log.Printf("TestQuoOverflow: num = %d", n)
 			n.Quo(d)
 		}
@@ -531,11 +537,12 @@ func TestQuoOverflow(t *testing.T) {
 }
 
 func TestMul(t *testing.T) {
-	require := require.New(t)
-	require.Equal(Infinity64, MustParse64("1e384").Mul(MustParse64("10")))
-	require.Equal(NegInfinity64, MustParse64("1e384").Mul(MustParse64("-10")))
-	require.Equal(NegInfinity64, MustParse64("-1e384").Mul(MustParse64("10")))
-	require.Equal(NegZero64, MustParse64("-1e384").Mul(Zero64))
-	require.Equal(Zero64, Zero64.Mul(Zero64))
-	require.Equal(Zero64, Zero64.Mul(MustParse64("100")))
+	t.Parallel()
+
+	equal(t, Infinity64, MustParse64("1e384").Mul(MustParse64("10")))
+	equal(t, NegInfinity64, MustParse64("1e384").Mul(MustParse64("-10")))
+	equal(t, NegInfinity64, MustParse64("-1e384").Mul(MustParse64("10")))
+	equal(t, NegZero64, MustParse64("-1e384").Mul(Zero64))
+	equal(t, Zero64, Zero64.Mul(Zero64))
+	equal(t, Zero64, Zero64.Mul(MustParse64("100")))
 }

--- a/decimal64scan_test.go
+++ b/decimal64scan_test.go
@@ -119,22 +119,20 @@ func BenchmarkDecimal64Scan(b *testing.B) {
 }
 
 func parseEquals64(t *testing.T) func(expected Decimal64, input string) {
-	require := require.New(t)
-
 	return func(expected Decimal64, input string) {
-		require.NotPanics(func() {
+		require.NotPanics(t, func() {
 			n := MustParse64(input)
-			require.Equal(expected, n, "%s", input)
+			requireEqualDecimal64(t, expected, n, "%s", input)
 		}, "%s", input)
 
 		n, err := Parse64(input)
-		require.NoError(err, "%s", input)
-		require.Equal(expected, n, "%s", input)
+		require.NoError(t, err, "%s", input)
+		requireEqualDecimal64(t, expected, n, "%s", input)
 
 		n = SNaN64
 		count, err := fmt.Sscanf(input, "%g", &n)
-		require.NoError(err, "%s", input)
-		require.Equal(1, count, "%s", input)
-		require.Equal(expected, n, "%s", input)
+		require.NoError(t, err, "%s", input)
+		require.Equal(t, 1, count, "%s", input)
+		requireEqualDecimal64(t, expected, n, "%s", input)
 	}
 }

--- a/decimal64scan_test.go
+++ b/decimal64scan_test.go
@@ -6,11 +6,11 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestParse64(t *testing.T) {
+	t.Parallel()
+
 	if testing.Short() {
 		t.Skip("skipping TestParse64 in short mode.")
 	}
@@ -27,6 +27,8 @@ func TestParse64(t *testing.T) {
 }
 
 func TestParse64Inf(t *testing.T) {
+	t.Parallel()
+
 	parseEquals64 := parseEquals64(t)
 
 	parseEquals64(Infinity64, "Inf")
@@ -42,10 +44,12 @@ func TestParse64Inf(t *testing.T) {
 // TODO: Find out what the correct behavior is with bad inputs
 // TODO: Does nan get returned if there are leading/trailing whitespaces?
 func TestParse64BadInputs(t *testing.T) {
+	t.Parallel()
+
 	test := func(input string) {
 		t.Helper()
 		d, _ := Parse64(input)
-		require.Equal(t, SNaN64.IsNaN(), d.IsNaN(), "input = %q", input)
+		equal(t, SNaN64.IsNaN(), d.IsNaN())
 	}
 	test("")
 	test(" ")
@@ -63,6 +67,8 @@ func TestParse64BadInputs(t *testing.T) {
 }
 
 func TestParse64BigExp(t *testing.T) {
+	t.Parallel()
+
 	parseEquals64 := parseEquals64(t)
 
 	parseEquals64(Zero64, "0e-9999")
@@ -77,6 +83,8 @@ func TestParse64BigExp(t *testing.T) {
 }
 
 func TestParse64LongMantissa(t *testing.T) {
+	t.Parallel()
+
 	parseEquals64 := parseEquals64(t)
 
 	parseEquals64(One64, "1000000000000000000000e-21")
@@ -84,18 +92,20 @@ func TestParse64LongMantissa(t *testing.T) {
 }
 
 func TestDecimal64ScanFlakyScanState(t *testing.T) {
-	requireFailAt := func(text string, failAt int) {
+	t.Parallel()
+
+	failAt := func(text string, failAt int) {
 		state := flakyScanState{
 			actual: &scanner{reader: strings.NewReader(text)},
 			failAt: failAt,
 		}
 		var d Decimal64
-		require.Error(t, d.Scan(&state, 'e'), "%d", failAt)
+		notnil(t, d.Scan(&state, 'e'))
 	}
 
-	requireFailAt("x", 0)
+	failAt("x", 0)
 	for i := 0; i < 7; i++ {
-		requireFailAt("-1.0e-3", i)
+		failAt("-1.0e-3", i)
 	}
 }
 
@@ -120,19 +130,19 @@ func BenchmarkDecimal64Scan(b *testing.B) {
 
 func parseEquals64(t *testing.T) func(expected Decimal64, input string) {
 	return func(expected Decimal64, input string) {
-		require.NotPanics(t, func() {
+		nopanic(t, func() {
 			n := MustParse64(input)
-			requireEqualDecimal64(t, expected, n, "%s", input)
-		}, "%s", input)
+			equalD64(t, expected, n, "%s", input)
+		})
 
 		n, err := Parse64(input)
-		require.NoError(t, err, "%s", input)
-		requireEqualDecimal64(t, expected, n, "%s", input)
+		isnil(t, err)
+		equalD64(t, expected, n, "%s", input)
 
 		n = SNaN64
 		count, err := fmt.Sscanf(input, "%g", &n)
-		require.NoError(t, err, "%s", input)
-		require.Equal(t, 1, count, "%s", input)
-		requireEqualDecimal64(t, expected, n, "%s", input)
+		isnil(t, err)
+		equal(t, 1, count)
+		equalD64(t, expected, n, "%s", input)
 	}
 }

--- a/decimalSuite_test.go
+++ b/decimalSuite_test.go
@@ -8,9 +8,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type opResult struct {
@@ -138,7 +135,7 @@ func TestFromSuite(t *testing.T) {
 					numTests++
 					t.Run(testVal.name, func(t *testing.T) {
 						dec64vals, err := convertToDec64(testVal)
-						require.NoError(t, err)
+						isnil(t, err)
 						if !runTest(t, scannedContext, dec64vals, testVal) {
 							runTest(t, scannedContext, dec64vals, testVal)
 						}
@@ -275,7 +272,8 @@ func runTest(t *testing.T, context Context64, expected opResult, testValStrings 
 			return true
 		}
 		if actual.text != testValStrings.expectedResult {
-			return assert.Failf(t, "unexpected result", "test:\n%s\ncalculated text: %s", testValStrings, actual.text)
+			t.Errorf("test:\n%s\ncalculated text: %s", testValStrings, actual.text)
+			return false
 		}
 		return true
 	}
@@ -283,12 +281,14 @@ func runTest(t *testing.T, context Context64, expected opResult, testValStrings 
 		e := expected.result.String()
 		a := actual.result.String()
 		if e != a {
-			return assert.Failf(t, "failed NaN test", "test:\n%s\ncalculated result: %v", testValStrings, actual.result)
+			t.Errorf("test:\n%s\ncalculated result: %v", testValStrings, actual.result)
+			return false
 		}
 		return true
 	}
 	if expected.result.Cmp(actual.result) != 0 {
-		return assert.Fail(t, "failed", "test:\n%s\ncalculated result: %v", testValStrings, actual.result)
+		t.Errorf("test:\n%s\ncalculated result: %v", testValStrings, actual.result)
+		return false
 	}
 	return true
 }

--- a/decimalSuite_test.go
+++ b/decimalSuite_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -141,7 +140,6 @@ func TestFromSuite(t *testing.T) {
 						dec64vals, err := convertToDec64(testVal)
 						require.NoError(t, err)
 						if !runTest(t, scannedContext, dec64vals, testVal) {
-							runtime.Breakpoint()
 							runTest(t, scannedContext, dec64vals, testVal)
 						}
 					})

--- a/flakyScanState_test.go
+++ b/flakyScanState_test.go
@@ -1,8 +1,6 @@
 package decimal
 
-import (
-	"fmt"
-)
+import "fmt"
 
 type flakyScanState struct {
 	actual fmt.ScanState

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,3 @@
 module github.com/anz-bank/decimal
 
 go 1.21
-
-require github.com/stretchr/testify v1.2.2
-
-require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-)

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,0 @@
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
-github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/stringScanner_test.go
+++ b/stringScanner_test.go
@@ -4,41 +4,39 @@ import (
 	"strings"
 	"testing"
 	"unicode"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestStringScannerSkipSpace(t *testing.T) {
-	require := require.New(t)
+	t.Parallel()
 
 	state := &scanner{reader: strings.NewReader(" \tx")}
 
 	state.SkipSpace()
 
 	r, size, err := state.ReadRune()
-	require.NoError(err)
-	require.Equal(1, size)
-	require.Equal('x', r)
+	isnil(t, err)
+	equal(t, 1, size)
+	equal(t, 'x', r)
 
-	require.NotPanics(func() { state.SkipSpace() })
+	nopanic(t, func() { state.SkipSpace() })
 }
 
 func TestStringScannerTokenSkipSpace(t *testing.T) {
-	require := require.New(t)
+	t.Parallel()
 
 	state := &scanner{reader: strings.NewReader(" \txyz")}
 
 	token, err := state.Token(false, unicode.IsLetter)
-	require.NoError(err)
-	require.Equal([]byte(nil), token)
+	isnil(t, err)
+	equal(t, 0, len(token))
 
 	token, err = state.Token(true, unicode.IsLetter)
-	require.NoError(err)
-	require.Equal([]byte("xyz"), token)
+	isnil(t, err)
+	equal(t, "xyz", string(token))
 }
 
 func TestStringScannerRead(t *testing.T) {
-	require := require.New(t)
+	t.Parallel()
 
 	state := &scanner{reader: strings.NewReader("hello world!")}
 
@@ -46,14 +44,14 @@ func TestStringScannerRead(t *testing.T) {
 	var world [10]byte
 
 	n, err := state.Read(hello[:])
-	require.NoError(err)
-	require.Equal(5, n)
-	require.Equal([]byte("hello"), hello[:])
+	isnil(t, err)
+	equal(t, 5, n)
+	equal(t, "hello", string(hello[:]))
 
 	state.SkipSpace()
 
 	n, err = state.Read(world[:])
-	require.NoError(err)
-	require.Equal(6, n)
-	require.Equal([]byte("world!"), world[:n])
+	isnil(t, err)
+	equal(t, 6, n)
+	equal(t, "world!", string(world[:n]))
 }

--- a/uint128_test.go
+++ b/uint128_test.go
@@ -1,57 +1,59 @@
 package decimal
 
-import (
-	"testing"
-
-	"github.com/stretchr/testify/require"
-)
+import "testing"
 
 func TestUint128Shl(t *testing.T) {
-	require.Equal(t, uint128T{}, uint128T{}.shl(1))
-	require.Equal(t, uint128T{2, 0}, uint128T{1, 0}.shl(1))
-	require.Equal(t, uint128T{4, 0}, uint128T{2, 0}.shl(1))
-	require.Equal(t, uint128T{4, 0}, uint128T{1, 0}.shl(2))
-	require.Equal(t, uint128T{0, 1}, uint128T{1, 42}.shl(64))
-	require.Equal(t, uint128T{0, 3}, uint128T{3, 42}.shl(64))
+	t.Parallel()
+
+	equal(t, uint128T{}, uint128T{}.shl(1))
+	equal(t, uint128T{2, 0}, uint128T{1, 0}.shl(1))
+	equal(t, uint128T{4, 0}, uint128T{2, 0}.shl(1))
+	equal(t, uint128T{4, 0}, uint128T{1, 0}.shl(2))
+	equal(t, uint128T{0, 1}, uint128T{1, 42}.shl(64))
+	equal(t, uint128T{0, 3}, uint128T{3, 42}.shl(64))
 }
 
 func TestUint128Sqrt(t *testing.T) {
-	require.EqualValues(t, 0, uint128T{}.sqrt())
-	require.EqualValues(t, 1, uint128T{1, 0}.sqrt())
-	require.EqualValues(t, 1, uint128T{2, 0}.sqrt())
-	require.EqualValues(t, 2, uint128T{4, 0}.sqrt())
-	require.EqualValues(t, 2, uint128T{8, 0}.sqrt())
-	require.EqualValues(t, 3, uint128T{9, 0}.sqrt())
-	require.EqualValues(t, int64(1<<32), uint128T{0, 1}.sqrt())
-	require.EqualValues(t, int64(2<<32), uint128T{0, 4}.sqrt())
+	t.Parallel()
+
+	equal(t, 0, uint128T{}.sqrt())
+	equal(t, 1, uint128T{1, 0}.sqrt())
+	equal(t, 1, uint128T{2, 0}.sqrt())
+	equal(t, 2, uint128T{4, 0}.sqrt())
+	equal(t, 2, uint128T{8, 0}.sqrt())
+	equal(t, 3, uint128T{9, 0}.sqrt())
+	equal(t, uint64(1<<32), uint128T{0, 1}.sqrt())
+	equal(t, uint64(2<<32), uint128T{0, 4}.sqrt())
 }
 
 func TestUint128DivBy10(t *testing.T) {
-	require.Equal(t, uint128T{0, 0}, uint128T{0, 0}.divBy10())
-	require.Equal(t, uint128T{0, 0}, uint128T{1, 0}.divBy10())
-	require.Equal(t, uint128T{0, 0}, uint128T{9, 0}.divBy10())
-	require.Equal(t, uint128T{1, 0}, uint128T{10, 0}.divBy10())
-	require.Equal(t, uint128T{1, 0}, uint128T{19, 0}.divBy10())
-	require.Equal(t, uint128T{2, 0}, uint128T{20, 0}.divBy10())
-	require.Equal(t, uint128T{9, 0}, uint128T{99, 0}.divBy10())
-	require.Equal(t, uint128T{10, 0}, uint128T{100, 0}.divBy10())
-	require.Equal(t, uint128T{9999, 0}, uint128T{99999, 0}.divBy10())
-	require.Equal(t, uint128T{10000, 0}, uint128T{100000, 0}.divBy10())
-	require.Equal(t, uint128T{(1 << 64) / 10, 0}, uint128T{0, 1}.divBy10())
-	require.Equal(t, uint128T{(2 << 64) / 10, 0}, uint128T{0, 2}.divBy10())
-	require.Equal(t,
+	t.Parallel()
+
+	equal(t, uint128T{0, 0}, uint128T{0, 0}.divBy10())
+	equal(t, uint128T{0, 0}, uint128T{1, 0}.divBy10())
+	equal(t, uint128T{0, 0}, uint128T{9, 0}.divBy10())
+	equal(t, uint128T{1, 0}, uint128T{10, 0}.divBy10())
+	equal(t, uint128T{1, 0}, uint128T{19, 0}.divBy10())
+	equal(t, uint128T{2, 0}, uint128T{20, 0}.divBy10())
+	equal(t, uint128T{9, 0}, uint128T{99, 0}.divBy10())
+	equal(t, uint128T{10, 0}, uint128T{100, 0}.divBy10())
+	equal(t, uint128T{9999, 0}, uint128T{99999, 0}.divBy10())
+	equal(t, uint128T{10000, 0}, uint128T{100000, 0}.divBy10())
+	equal(t, uint128T{(1 << 64) / 10, 0}, uint128T{0, 1}.divBy10())
+	equal(t, uint128T{(2 << 64) / 10, 0}, uint128T{0, 2}.divBy10())
+	equal(t,
 		uint128T{((123 << 64) / 10) % (1 << 64), ((123 << 64) / 10) >> 64},
 		uint128T{0, 123}.divBy10(),
 	)
-	require.Equal(t,
+	equal(t,
 		uint128T{((123456789 << 64) / 10) % (1 << 64), ((123456789 << 64) / 10) >> 64},
 		uint128T{0, 123456789}.divBy10(),
 	)
-	require.Equal(t,
+	equal(t,
 		uint128T{((123 << 56 << 64) / 10) % (1 << 64), ((123 << 56 << 64) / 10) >> 64},
 		uint128T{0, 123 << 56}.divBy10(),
 	)
-	require.Equal(t,
+	equal(t,
 		uint128T{((1<<128 - 1) / 10) % (1 << 64), ((1<<128 - 1) / 10) >> 64},
 		uint128T{1<<64 - 1, 1<<64 - 1}.divBy10(),
 	)

--- a/util_test.go
+++ b/util_test.go
@@ -1,37 +1,122 @@
 package decimal
 
-import (
-	"testing"
+import "testing"
 
-	"github.com/stretchr/testify/require"
-)
+func check(t *testing.T, ok bool) bool {
+	t.Helper()
+	if !ok {
+		t.Errorf("expected true")
+		return false
+	}
+	return true
+}
+
+func epsilon(t *testing.T, a, b float64) bool {
+	t.Helper()
+	if a/b-1 > 0.00000001 {
+		t.Errorf("%f and %f too dissimilar", a, b)
+		return false
+	}
+	return true
+}
+
+func equal[T comparable](t *testing.T, a, b T) bool {
+	t.Helper()
+	if a != b {
+		t.Errorf("expected %+v, got %+v", a, b)
+		return false
+	}
+	return true
+}
+
+func equalD64(t *testing.T, expected, actual Decimal64, fmtAndArgs ...any) {
+	t.Helper()
+	equal(t, expected.bits, actual.bits)
+}
+
+func isnil(t *testing.T, a any) bool {
+	t.Helper()
+	if a != nil {
+		t.Errorf("expected nil, got %+v", a)
+		return false
+	}
+	return true
+}
+
+func nopanic(t *testing.T, f func()) (b bool) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("panic: %+v", r)
+			b = false
+		}
+	}()
+	f()
+	return true
+}
+
+func notequal[T comparable](t *testing.T, a, b T) bool {
+	t.Helper()
+	if a == b {
+		t.Errorf("equal values %+v", a)
+		return false
+	}
+	return true
+}
+
+func notnil(t *testing.T, a any) bool {
+	t.Helper()
+	if a == nil {
+		t.Errorf("expected non-nil")
+		return false
+	}
+	return true
+}
+
+func panics(t *testing.T, f func()) (b bool) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic")
+			b = false
+		}
+	}()
+	f()
+	return true
+}
 
 func TestDiv10_64(t *testing.T) {
+	t.Parallel()
+
 	for i := uint64(0); i <= 10000; i++ {
 		d := uint128T{i, 0}.divBy10().lo
-		require.EqualValues(t, i/10, d, "%d/10 ≠ %d (expecting %d)", i, d, i/10)
+		equal(t, i/10, d)
 	}
 }
 
 func TestDiv10_64_po10(t *testing.T) {
+	t.Parallel()
+
 	for i, u := range tenToThe128 {
 		var e uint128T
 		if i > 0 {
 			e = tenToThe128[i-1]
 		}
 		a := u.divBy10()
-		require.EqualValues(t, e, a, "%v/10 ≠ %v (expecting %d)", u, a, e)
+		equal(t, e, a)
 	}
 }
 
 func TestUmul64_po10(t *testing.T) {
+	t.Parallel()
+
 	for i, u := range tenToThe128 {
 		if u.hi == 0 {
 			for j, v := range tenToThe128 {
 				if v.hi == 0 {
 					e := tenToThe128[i+j]
 					a := umul64(u.lo, v.lo)
-					require.EqualValues(t, e, a, "%v/10 ≠ %v (expecting %d)", u, a, e)
+					equal(t, e, a)
 				}
 			}
 		}


### PR DESCRIPTION
- Remove testify.
- Fix `go test -tags=decimal-debug` failures.
- Make all test cases parallel.