### PR TITLE
Faster add, etc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,12 @@ ci: test-all no-allocs
 test-all: test test-32
 
 .PHONY: test
-test:
-	go test $(GOTESTFLAGS)
+test: test-release
 	go test $(GOTESTFLAGS) -tags=decimal_debug
+
+.PHONY: test-release
+test-release:
+	go test $(GOTESTFLAGS)
 
 .PHONY: test-32
 test-32:
@@ -59,7 +62,7 @@ lint: build-linux
 
 .INTERMEDIATE: %.prof
 %.prof: $(wildcard *.go)
-	go test -$*profile $@ -count=10 $(GOPROFILEFLAGS)
+	go test -$*profile $@ $(GOPROFILEFLAGS)
 
 .PHONY: bench
 bench: bench.txt

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all
-all: test-all build-linux lint
+all: test-all build-linux lint no-allocs
 
 .PHONY: ci
 ci: test-all no-allocs

--- a/decimal64.go
+++ b/decimal64.go
@@ -222,8 +222,7 @@ func renormalize(exp int16, significand uint64) (int16, uint64) {
 }
 
 // roundStatus gives info about the truncated part of the significand that can't be fully stored in 16 decimal digits.
-func roundStatus(significand uint64, exp int16, targetExp int16) discardedDigit {
-	expDiff := targetExp - exp
+func roundStatus(significand uint64, expDiff int16) discardedDigit {
 	if expDiff > 19 && significand != 0 {
 		return lt5
 	}
@@ -528,15 +527,6 @@ func (d Decimal64) Class() string {
 		return "+Subnormal-Subnormal"[10*dp.sign : 10*(dp.sign+1)]
 	}
 	return "+Normal-Normal"[7*dp.sign : 7*(dp.sign+1)]
-}
-
-// numDecimalDigitsU64 returns the magnitude (number of digits) of a uint64.
-func numDecimalDigitsU64(n uint64) int16 {
-	numDigits := int16(bits.Len64(n) * 77 / 256) // ~ 3/10
-	if n >= tenToThe[uint(numDigits)%uint(len(tenToThe))] {
-		numDigits++
-	}
-	return numDigits
 }
 
 func checkNan(d, e Decimal64, dp, ep *decParts) (Decimal64, bool) {

--- a/decimal64_test.go
+++ b/decimal64_test.go
@@ -315,16 +315,6 @@ func TestDecimal64isZero(t *testing.T) {
 	check(t, !One64.IsZero())
 }
 
-func TestNumDecimalDigits(t *testing.T) {
-	t.Parallel()
-
-	for i, num := range tenToThe {
-		for j := uint64(1); j < 10 && i < 19; j++ {
-			equal(t, i+1, int(numDecimalDigitsU64(num*j)))
-		}
-	}
-}
-
 func TestIsSubnormal(t *testing.T) {
 	t.Parallel()
 

--- a/decimal64decParts.go
+++ b/decimal64decParts.go
@@ -111,13 +111,6 @@ func (dp *decParts) separation(ep *decParts) int16 {
 	return sep
 }
 
-// separation gets the separation in decimal places of the MSD's of two decimal 64s
-func (dp *decParts) separationV2(ep *decParts) int16 {
-	sep := int16(numDecimalDigitsU64(dp.significand.lo)) + dp.exp
-	sep -= int16(numDecimalDigitsU64(ep.significand.lo)) + ep.exp
-	return sep
-}
-
 // removeZeros removes zeros and increments the exponent to match.
 func (dp *decParts) removeZeros() {
 	e := dp.exp

--- a/decimal64decParts.go
+++ b/decimal64decParts.go
@@ -38,6 +38,38 @@ func (ans *decParts) add128(dp, ep *decParts) {
 	}
 }
 
+// add64 adds the low 64 bits of two decParts
+func (ans *decParts) add64(dp, ep *decParts) {
+	ans.exp = dp.exp
+	switch {
+	case dp.sign == ep.sign:
+		ans.sign = dp.sign
+		ans.significand.lo = dp.significand.lo + ep.significand.lo
+	case dp.significand.lt(&ep.significand):
+		ans.sign = ep.sign
+		ans.significand.lo = ep.significand.lo - dp.significand.lo
+	case ep.significand.lt(&dp.significand):
+		ans.sign = dp.sign
+		ans.significand.lo = dp.significand.lo - ep.significand.lo
+	}
+}
+
+// add128 adds two decParts with full precision in 128 bits of significand
+func (ans *decParts) add128V2(dp, ep *decParts) {
+	ans.exp = dp.exp
+	switch {
+	case dp.sign == ep.sign:
+		ans.sign = dp.sign
+		ans.significand.add(&dp.significand, &ep.significand)
+	case dp.significand.lt(&ep.significand):
+		ans.sign = ep.sign
+		ans.significand.sub(&ep.significand, &dp.significand)
+	case ep.significand.lt(&dp.significand):
+		ans.sign = dp.sign
+		ans.significand.sub(&dp.significand, &ep.significand)
+	}
+}
+
 func (dp *decParts) matchScales128(ep *decParts) {
 	expDiff := ep.exp - dp.exp
 	if (ep.significand != uint128T{0, 0}) {
@@ -56,10 +88,10 @@ func (dp *decParts) roundToLo() discardedDigit {
 
 	if ds := &dp.significand; ds.hi > 0 || ds.lo >= 10*decimal64Base {
 		var remainder uint64
-		expDiff := ds.numDecimalDigits() - 16
+		expDiff := int16(ds.numDecimalDigits()) - 16
 		dp.exp += expDiff
 		remainder = ds.divrem64(ds, tenToThe[expDiff])
-		rndStatus = roundStatus(remainder, 0, expDiff)
+		rndStatus = roundStatus(remainder, expDiff)
 	}
 	return rndStatus
 }
@@ -74,7 +106,16 @@ func (dp *decParts) isSubnormal() bool {
 
 // separation gets the separation in decimal places of the MSD's of two decimal 64s
 func (dp *decParts) separation(ep *decParts) int16 {
-	return dp.significand.numDecimalDigits() + dp.exp - ep.significand.numDecimalDigits() - ep.exp
+	sep := int16(dp.significand.numDecimalDigits()) + dp.exp
+	sep -= int16(ep.significand.numDecimalDigits()) + ep.exp
+	return sep
+}
+
+// separation gets the separation in decimal places of the MSD's of two decimal 64s
+func (dp *decParts) separationV2(ep *decParts) int16 {
+	sep := int16(numDecimalDigitsU64(dp.significand.lo)) + dp.exp
+	sep -= int16(numDecimalDigitsU64(ep.significand.lo)) + ep.exp
+	return sep
 }
 
 // removeZeros removes zeros and increments the exponent to match.
@@ -115,18 +156,17 @@ func (dp *decParts) isinf() bool {
 	return dp.fl == flInf
 }
 
-func (dp *decParts) rescale(targetExp int16) (rndStatus discardedDigit) {
+func (dp *decParts) rescale(targetExp int16) discardedDigit {
 	expDiff := targetExp - dp.exp
-	mag := dp.significand.numDecimalDigits()
-	rndStatus = roundStatus(dp.significand.lo, dp.exp, targetExp)
-	if expDiff > mag {
+	rndStatus := roundStatus(dp.significand.lo, expDiff)
+	if expDiff > int16(dp.significand.numDecimalDigits()) {
 		dp.significand.lo, dp.exp = 0, targetExp
-		return
+		return rndStatus
 	}
 	divisor := tenToThe[expDiff]
 	dp.significand.lo = dp.significand.lo / divisor
 	dp.exp = targetExp
-	return
+	return rndStatus
 }
 
 func (dp *decParts) unpack(d Decimal64) {
@@ -142,9 +182,6 @@ func (dp *decParts) unpackV2(d Decimal64) {
 		//   EE ∈ {00, 01, 10}
 		dp.exp = int16((d.bits>>(63-10))&(1<<10-1)) - expOffset
 		dp.significand.lo = d.bits & (1<<53 - 1)
-		if dp.significand.lo == 0 {
-			dp.exp = 0
-		}
 	case flNormal51:
 		// s 11EEeeeeeeee (100)t tttttttttt tttttttttt tttttttttt tttttttttt tttttttttt
 		//     EE ∈ {00, 01, 10}

--- a/decimal64math_test.go
+++ b/decimal64math_test.go
@@ -1,7 +1,6 @@
 package decimal
 
 import (
-	"cmp"
 	"fmt"
 	"log"
 	"testing"
@@ -57,8 +56,11 @@ func TestDecimal64Add(t *testing.T) {
 			e := MustParse64(expected)
 			x := MustParse64(a)
 			y := MustParse64(b)
+			if ctx == nil {
+				ctx = &DefaultContext64
+			}
 			replayOnFail(t, func() {
-				z := cmp.Or(ctx, &DefaultContext64).Add(x, y)
+				z := ctx.Add(x, y)
 				equalD64(t, e, z)
 			})
 		}

--- a/decimal64math_test.go
+++ b/decimal64math_test.go
@@ -1,6 +1,7 @@
 package decimal
 
 import (
+	"cmp"
 	"fmt"
 	"log"
 	"testing"
@@ -48,6 +49,25 @@ func TestDecimal64Add(t *testing.T) {
 		func(a, b int64) int64 { return a + b },
 		func(a, b Decimal64) Decimal64 { return a.Add(b) },
 	)
+
+	add := func(a, b, expected string, ctx *Context64) func(*testing.T) {
+		return func(*testing.T) {
+			t.Helper()
+
+			e := MustParse64(expected)
+			x := MustParse64(a)
+			y := MustParse64(b)
+			replayOnFail(t, func() {
+				z := cmp.Or(ctx, &DefaultContext64).Add(x, y)
+				equalD64(t, e, z)
+			})
+		}
+	}
+
+	t.Run("tiny-neg", add("1E-383", "-1E-398", "9.99999999999999E-384", nil))
+
+	he := Context64{Rounding: HalfEven}
+	t.Run("round-even", add("12345678", "0.1234567850000000", "12345678.12345678", &he))
 }
 
 func TestDecimal64AddNaN(t *testing.T) {

--- a/decimal64math_test.go
+++ b/decimal64math_test.go
@@ -67,7 +67,7 @@ func TestDecimal64Add(t *testing.T) {
 	t.Run("tiny-neg", add("1E-383", "-1E-398", "9.99999999999999E-384", nil))
 
 	he := Context64{Rounding: HalfEven}
-	t.Run("round-even", add("12345678", "0.1234567850000000", "12345678.12345678", &he))
+	t.Run("round-even", add("12345678", "0.123456785", "12345678.12345678", &he))
 }
 
 func TestDecimal64AddNaN(t *testing.T) {

--- a/uint128.go
+++ b/uint128.go
@@ -10,16 +10,25 @@ type uint128T struct {
 	lo, hi uint64
 }
 
-func (a *uint128T) numDecimalDigits() int16 {
+func (a *uint128T) numDecimalDigits() int {
 	if a.hi == 0 {
 		return numDecimalDigitsU64(a.lo)
 	}
 	bitSize := 65 + bits.Len64(a.hi)
-	numDigitsEst := int16(bitSize * 77 / 256)
-	if !a.lt(&tenToThe128[uint(numDigitsEst)%uint(len(tenToThe128))]) {
+	numDigitsEst := uint(bitSize) * 77 / 256
+	if !a.lt(&tenToThe128[numDigitsEst%uint(len(tenToThe128))]) {
 		numDigitsEst++
 	}
-	return numDigitsEst
+	return int(numDigitsEst)
+}
+
+// numDecimalDigitsU64 returns the magnitude (number of digits) of a uint64.
+func numDecimalDigitsU64(n uint64) int {
+	numDigits := uint(bits.Len64(n)) * 77 / 256 // ~ 3/10
+	if n >= tenToThe[numDigits%uint(len(tenToThe))] {
+		numDigits++
+	}
+	return int(numDigits)
 }
 
 var tenToThe128 = func() [64]uint128T {

--- a/uint128_test.go
+++ b/uint128_test.go
@@ -22,6 +22,16 @@ func TestUint128Shl(t *testing.T) {
 	test(uint128T{0, 3}, uint128T{3, 42}, 64)
 }
 
+func TestNumDecimalDigits(t *testing.T) {
+	t.Parallel()
+
+	for i, num := range tenToThe {
+		for j := uint64(1); j < 10 && i < 19; j++ {
+			equal(t, i+1, int(numDecimalDigitsU64(num*j)))
+		}
+	}
+}
+
 func TestSqrtu64(t *testing.T) {
 	t.Parallel()
 

--- a/util_test.go
+++ b/util_test.go
@@ -2,24 +2,20 @@ package decimal
 
 import "testing"
 
-func errorf(t *testing.T, format string, args ...any) {
-	t.Helper()
-	t.Errorf(format, args...)
-}
-
-func replayOnFail(t *testing.T, f func()) {
+func replayOnFail(t *testing.T, f func()) pass {
 	t.Helper()
 	alreadyFailed := t.Failed()
 	defer func() {
 		t.Helper()
 		if r := recover(); r != nil {
-			errorf(t, "panic: %+v", r)
+			t.Errorf("panic: %+v", r)
 		}
 		if !alreadyFailed && t.Failed() {
 			f() // Set a breakpoint here to replay the first failed test.
 		}
 	}()
 	f()
+	return !pass(alreadyFailed && t.Failed())
 }
 
 type pass bool
@@ -33,7 +29,7 @@ func (p pass) Or(f func()) {
 func check(t *testing.T, ok bool) pass {
 	t.Helper()
 	if !ok {
-		errorf(t, "expected true")
+		t.Errorf("expected true")
 		return false
 	}
 	return true
@@ -42,7 +38,7 @@ func check(t *testing.T, ok bool) pass {
 func epsilon(t *testing.T, a, b float64) pass {
 	t.Helper()
 	if a/b-1 > 0.00000001 {
-		errorf(t, "%f and %f too dissimilar", a, b)
+		t.Errorf("%f and %f too dissimilar", a, b)
 		return false
 	}
 	return true
@@ -51,7 +47,7 @@ func epsilon(t *testing.T, a, b float64) pass {
 func equal[T comparable](t *testing.T, a, b T) pass {
 	t.Helper()
 	if a != b {
-		errorf(t, "expected %+v, got %+v", a, b)
+		t.Errorf("expected %+v, got %+v", a, b)
 		return false
 	}
 	return true
@@ -65,7 +61,7 @@ func equalD64(t *testing.T, expected, actual Decimal64) pass {
 func isnil(t *testing.T, a any) pass {
 	t.Helper()
 	if a != nil {
-		errorf(t, "expected nil, got %+v", a)
+		t.Errorf("expected nil, got %+v", a)
 		return false
 	}
 	return true
@@ -76,7 +72,7 @@ func nopanic(t *testing.T, f func()) (b pass) {
 	defer func() {
 		t.Helper()
 		if r := recover(); r != nil {
-			errorf(t, "panic: %+v", r)
+			t.Errorf("panic: %+v", r)
 			b = false
 		}
 	}()
@@ -87,7 +83,7 @@ func nopanic(t *testing.T, f func()) (b pass) {
 func notequal[T comparable](t *testing.T, a, b T) pass {
 	t.Helper()
 	if a == b {
-		errorf(t, "equal values %+v", a)
+		t.Errorf("equal values %+v", a)
 		return false
 	}
 	return true
@@ -96,7 +92,7 @@ func notequal[T comparable](t *testing.T, a, b T) pass {
 func notnil(t *testing.T, a any) pass {
 	t.Helper()
 	if a == nil {
-		errorf(t, "expected non-nil")
+		t.Errorf("expected non-nil")
 		return false
 	}
 	return true
@@ -107,7 +103,7 @@ func panics(t *testing.T, f func()) (b pass) {
 	defer func() {
 		t.Helper()
 		if r := recover(); r == nil {
-			errorf(t, "expected panic")
+			t.Errorf("expected panic")
 			b = false
 		}
 	}()


### PR DESCRIPTION
- Make Add faster.
- Add checks that most operations never allocate.
- Remove `-count=10` from profiler make rules.
- Rename `cmp` to `cmp64` to avoid collision with standard package.
- Rework test suite ops as a map of functions.
- Remove `errorf` helper (no value-add).