### PR TITLE
refactor decimal package to decimal/d64.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,22 @@
 # decimal
 
-This library implements fixed-precision decimal numbers based on the IEEE 754-2019 standard;
-<https://ieeexplore.ieee.org/document/8766229>.
-More info can be found at:
-<http://speleotrove.com/decimal/>
+This library implements fixed-precision decimal numbers based on the [IEEE 754-2019 standard](https://ieeexplore.ieee.org/document/8766229).
+More info can be found at <http://speleotrove.com/decimal/>.
 
 ## Features
 
 - Decimal64, partial implementation of the ieee-754R standard
-- Half up and half even rounding
+- Rounding modes: half up, half even, down (towards zero)
 - Up to 3 times faster than arbitrary precision decimal libraries in Go
 
 ## Goals
 
-- Implement 128 bit decimal
+- Implement 128 bit decimal.
 - Implement as much of <https://speleotrove.com/decimal/decarith.pdf> as possible.
 
 ## Installation and use
 
-Run `go get github.com/anz-bank/decimal`
+Run `go get github.com/anz-bank/decimal/d64`
 
 ```go
 package main
@@ -26,14 +24,14 @@ package main
 import (
 	"fmt"
 
-	"github.com/anz-bank/decimal"
+	"github.com/anz-bank/decimal/d64"
 )
 
 func main() {
-	var a decimal.Decimal64
-	b := decimal.MustParse64("0.1")
-	c := decimal.MustParse64("0.3")
-	d := decimal.New64FromInt64(123456)
+	var a d64.Decimal
+	b := d64.MustParse("0.1")
+	c := d64.MustParse("0.3")
+	d := d64.NewFromInt64(123456)
 
 	fmt.Println(a, b, c, d)
 }
@@ -41,47 +39,38 @@ func main() {
 
 ## Usage notes
 
+The d128 package doesn't exist yet, so d64 is assumed below.
+
 ### Formatting
 
-`Decimal64` provides numerous ways to present numbers for human and machine
-consumption.
+`Decimal` provides numerous ways to present numbers for human and machine consumption.
 
-`Decimal64` implements the following conventional interfaces:
+`Decimal` implements the following conventional interfaces:
 
 - `fmt`: `Formatter`, `Scanner` and `Stringer`
-  - It currently supports specifying a precision argument, e.g., `%.10f` for the
-    `f` and `F` verbs, while support for `g` and `G` is [planned](https://github.com/anz-bank/decimal/issues/72), as is [support for width specifiers](https://github.com/anz-bank/decimal/issues/72).
+  - It currently supports specifying a precision argument, e.g., `%.10f` for the `f` and `F` verbs, while support for `g` and `G` is [planned](https://github.com/anz-bank/decimal/issues/72), as is [support for width specifiers](https://github.com/anz-bank/decimal/issues/72).
 - `json`: `Marshaller` and `Unmarshaller`
 - `encoding`: `BinaryMarshaler`, `BinaryUnmarshaler`, `TextMarshaler` and `TextUnmarshaler`
-- `encoging/gob`: `GobEncoder` and `GobDecoder`
+- `encoding/gob`: `GobEncoder` and `GobDecoder`
 
-The following methods provide more direct access to the internal methods used to
-implement `fmt.Formatter`. (For maximum control, use `fmt.Printf` &co or invoke
-the `fmt.Formatter` interface directly.)
+The following methods provide more direct access to the internal methods used to implement `fmt.Formatter`.
+For maximum control, use `fmt.Printf` &co or invoke the `fmt.Formatter` interface directly.
 
-- `Decimal64.Append` formats straight into a `[]byte` buffer.
-- `Decimal64.Text` formats in the same way, but returns a `string`.
+- `Decimal.Append` formats straight into a `[]byte` buffer.
+- `Decimal.Text` formats in the same way, but returns a `string`.
 
 ### Debugging
 
-tl;dr: Use the `decimal_debug` compiler tag during debugging to greatly ease
-runtime inspection of `Decimal64` values.
+tl;dr: Use the `decimal_debug` compiler tag during debugging to greatly ease runtime inspection of `Decimal` values.
 
-Debugging with the `decimal` package can be challeging because a `Decimal64`
-number is encoded in a `uint64` and the values it holds are inscrutable even to
-the trained eye. For example, the number one `decimal.One64` is represented
-internally as the number `3450757314565799936` (`2fe38d7ea4c68000` in
-hexadecimal).
+Debugging with the `decimal` package can be challenging because a `Decimal` number is encoded in a `uint64` and the values it holds are inscrutable even to the trained eye.
+For example, the number one `One` is represented internally as the number `3450757314565799936` (`2fe38d7ea4c68000` in hexadecimal).
 
-To ease debugging, `Decimal64` holds an optional `debugInfo` structure that
-contains a string representation and unpacked components of the `uint64`
-representation for every `Decimal64` value.
+To ease debugging, `Decimal` holds an optional `debugInfo` structure that contains a string representation and unpacked components of the `uint64` representation for every `Decimal` value.
 
-This feature is enabled through the `decimal_debug` compiler tag. This is done
-at compile time instead of through runtime flags because having the structure
-there even if not used would double the size of each number and greatly increase
-the cost of using it. The size and runtime cost of this feature is zero when the
-compiler tag is not present.
+This feature is enabled through the `decimal_debug` compiler tag.
+This is done at compile time instead of through runtime flags because having the structure there, even if not used, would double the size of each number and greatly increase the cost of using it.
+The size and runtime cost of this feature is zero when the compiler tag is not present.
 
 ## Docs
 
@@ -89,21 +78,23 @@ compiler tag is not present.
 
 ## Why decimal?
 
-Binary floating point numbers are fundamentally flawed when it comes to representing exact numbers in a decimal world. Just like 1/3 can't be represented in base 10 (it evaluates to 0.3333333333 repeating), 1/10 can't be represented in binary.
+Binary floating point numbers are fundamentally flawed when it comes to representing exact numbers in a decimal world.
+Just like 1/3 can't be represented in base 10 (it evaluates to 0.3333333333 repeating), 1/10 can't be represented in binary.
 The solution is to use a decimal floating point number.
 Binary floating point numbers (often just called floating point numbers) are usually in the form `Sign * Significand * 2 ^ exp` and decimal floating point numbers change this to `Sign * Significand * 10 ^ exp`.
 The use of base 10 eliminates the decimal fraction problem.
 
 ## Why fixed precision?
 
-Most implementations of a decimal floating point datatype implement an *arbitrary precision* type, which often uses an underlying big int. This gives flexibility in that as the number grows, the number of bits assigned to the number grows ( hence the term "arbitrary precision").
-This library is different. It uses a 64-bit decimal datatype as specified in the IEEE-754R standard. This sacrifices the ability to represent arbitrarily large numbers, but is much faster than arbitrary precision libraries.
+Most implementations of a decimal floating point datatype implement an *arbitrary precision* type, which often uses an underlying big int.
+This gives flexibility in that as the number grows, the number of bits assigned to the number grows (hence the term "arbitrary precision").
+This library is different.
+It uses a 64-bit decimal datatype as specified in the IEEE-754R standard.
+This sacrifices the ability to represent arbitrarily large numbers, but is much faster than arbitrary precision libraries.
 There are two main reasons for this:
 
-1. The fixed-size data type is a `uint64` under the hood and never requires heap
-   allocation.
-2. All the algorithms can hard-code assumptions about the number of bits to work
-   with.
+1. The fixed-size data type is a `uint64` under the hood and never requires heap allocation.
+2. All the algorithms can hard-code assumptions about the number of bits to work with.
    In fact, many of the operations work on the entire number as a single unit
    using 64-bit integer arithmetic and, on the occasions it needs to use more,
    128 bits always suffices.

--- a/d64/bench.txt
+++ b/d64/bench.txt
@@ -1,0 +1,20 @@
+goos: darwin
+goarch: arm64
+pkg: github.com/anz-bank/decimal/d64
+cpu: Apple M4 Max
+BenchmarkIODecimalString-16     	45000848	        26.82 ns/op	      16 B/op	       1 allocs/op
+BenchmarkIODecimalString2-16    	50688696	        22.96 ns/op	      13 B/op	       0 allocs/op
+BenchmarkIODecimalFormat-16     	16520335	        72.77 ns/op	      56 B/op	       3 allocs/op
+BenchmarkIODecimalAppend-16     	65414551	        18.39 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDecimalAbs-16          	1000000000	         0.5281 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDecimalAdd-16          	169439442	         7.296 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDecimalCmp-16          	121484217	         9.711 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDecimalMul-16          	155150511	         7.752 ns/op	       0 B/op	       0 allocs/op
+BenchmarkFloat64Mul-16          	1000000000	         0.8068 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDecimalQuo-16          	217405482	         5.582 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDecimalSqrt-16         	216664428	         5.596 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDecimalSub-16          	164511207	         7.313 ns/op	       0 B/op	       0 allocs/op
+BenchmarkIOParse-16             	 6746329	       181.2 ns/op	      64 B/op	       2 allocs/op
+BenchmarkIODecimalScan-16       	 9673527	       123.8 ns/op	      80 B/op	       2 allocs/op
+PASS
+ok  	github.com/anz-bank/decimal/d64	21.807s

--- a/d64/const.go
+++ b/d64/const.go
@@ -1,0 +1,73 @@
+package d64
+
+// Zero is 0 represented as a [Decimal].
+var Zero = newFromParts(0, 0, 0)
+
+// NegZero is -0 represented as a [Decimal].
+// Note that [Zero] != NegZero, but [Zero].Equal(NegZero) returns true.
+var NegZero = newFromParts(1, 0, 0)
+
+// One is 1 represented as a [Decimal].
+var One = newFromParts(0, -15, decimalBase)
+
+// NegOne is -1 represented as a [Decimal].
+var NegOne = newFromParts(1, -15, decimalBase)
+
+// Inf is ∞ represented as a [Decimal].
+var Inf = newDec(inf)
+
+// NegInf is -∞ represented as a [Decimal].
+var NegInf = newDec(neg | inf)
+
+// QNaN is a quiet NaN represented as a [Decimal].
+var QNaN = newDec(0x7c << 56)
+
+// SNaN is a signalling NaN represented as a [Decimal].
+// Note that the decimal never signals on NaNs but some operations treat sNaN
+// differently to NaN.
+var SNaN = newDec(0x7e << 56)
+
+// Pi represents the transcendental number π.
+var Pi = newFromParts(0, -15, 3_141592653589793)
+
+// E represents the transcendental number e (lim[n→∞](1+1/n)ⁿ).
+var E = newFromParts(0, -15, 2_718281828459045)
+
+const neg uint64 = 0x80 << 56
+const inf uint64 = 0x78 << 56
+
+const decimalBase uint64 = 1_000_000_000_000_000 // 1E15
+const decimalDigits = 16
+
+// maxSig is the maximum significand possible that fits in 16 decimal places.
+const maxSig = 10*decimalBase - 1
+
+const expOffset = 398
+const expMax = 369
+
+// Max is the highest finite number representable as a [Decimal].
+// It has the value 9.999999999999999E+384.
+var Max = newFromParts(0, expMax, maxSig)
+
+// NegMax is the lowest finite number representable as a [Decimal].
+// It has the value -9.999999999999999E+384.
+var NegMax = newFromParts(1, expMax, maxSig)
+
+// Min is the closest positive number to zero.
+// It has the value 1E-398.
+var Min = newFromParts(0, -398, 1)
+
+// NegMin is the closest negative number to zero.
+// It has the value -1E-398.
+var NegMin = newFromParts(1, -398, 1)
+
+var zeroes = [2]Decimal{Zero, NegZero}
+var infinities = [2]Decimal{Inf, NegInf}
+
+// DefaultContext is the context that arithmetic functions will use in order to
+// do calculations.
+// Setting this context to a different value will globally affect all
+// [Decimal] methods whose behavior depends on context.
+// Note that all such methods are also available as direct methods of [Context].
+// It uses [HalfUp] rounding.
+var DefaultContext = Context{Rounding: HalfUp}

--- a/d64/const_test.go
+++ b/d64/const_test.go
@@ -1,0 +1,15 @@
+package d64
+
+import "testing"
+
+func TestPi(t *testing.T) {
+	t.Parallel()
+
+	equal(t, "3.141592653589793", Pi.String())
+}
+
+func TestE(t *testing.T) {
+	t.Parallel()
+
+	equal(t, "2.718281828459045", E.String())
+}

--- a/d64/decParts.go
+++ b/d64/decParts.go
@@ -1,0 +1,213 @@
+package d64
+
+// decParts stores the constituting decParts of a decimal64.
+type decParts struct {
+	significand uint128T
+	exp         int16
+	sign        int8
+	fl          flavor
+}
+
+func unpack(d Decimal) decParts {
+	var dp decParts
+	dp.unpack(d)
+	return dp
+}
+
+func (dp *decParts) decimal() Decimal {
+	return newFromParts(dp.sign, dp.exp, dp.significand.lo)
+}
+
+// add128 adds two decParts with full precision in 128 bits of significand
+func (ans *decParts) add128(dp, ep *decParts) {
+	dp.matchScales128(ep)
+	ans.exp = dp.exp
+	if dp.sign == ep.sign {
+		ans.sign = dp.sign
+		ans.significand.add(&dp.significand, &ep.significand)
+	} else {
+		if dp.significand.lt(&ep.significand) {
+			ans.sign = ep.sign
+			ans.significand.sub(&ep.significand, &dp.significand)
+		} else if ep.significand.lt(&dp.significand) {
+			ans.sign = dp.sign
+			ans.significand.sub(&dp.significand, &ep.significand)
+		} else {
+			ans.significand = uint128T{0, 0}
+		}
+	}
+}
+
+// add64 adds the low 64 bits of two decParts
+func (ans *decParts) add64(dp, ep *decParts) {
+	ans.exp = dp.exp
+	switch {
+	case dp.sign == ep.sign:
+		ans.sign = dp.sign
+		ans.significand.lo = dp.significand.lo + ep.significand.lo
+	case dp.significand.lt(&ep.significand):
+		ans.sign = ep.sign
+		ans.significand.lo = ep.significand.lo - dp.significand.lo
+	case ep.significand.lt(&dp.significand):
+		ans.sign = dp.sign
+		ans.significand.lo = dp.significand.lo - ep.significand.lo
+	}
+}
+
+// add128 adds two decParts with full precision in 128 bits of significand
+func (ans *decParts) add128V2(dp, ep *decParts) {
+	ans.exp = dp.exp
+	switch {
+	case dp.sign == ep.sign:
+		ans.sign = dp.sign
+		ans.significand.add(&dp.significand, &ep.significand)
+	case dp.significand.lt(&ep.significand):
+		ans.sign = ep.sign
+		ans.significand.sub(&ep.significand, &dp.significand)
+	case ep.significand.lt(&dp.significand):
+		ans.sign = dp.sign
+		ans.significand.sub(&dp.significand, &ep.significand)
+	}
+}
+
+func (dp *decParts) matchScales128(ep *decParts) {
+	expDiff := ep.exp - dp.exp
+	if (ep.significand != uint128T{0, 0}) {
+		if expDiff < 0 {
+			dp.significand.mul(&dp.significand, &tenToThe128[-expDiff])
+			dp.exp += expDiff
+		} else if expDiff > 0 {
+			ep.significand.mul(&ep.significand, &tenToThe128[expDiff])
+			ep.exp -= expDiff
+		}
+	}
+}
+
+func (dp *decParts) roundToLo() discardedDigit {
+	var rndStatus discardedDigit
+
+	if ds := &dp.significand; ds.hi > 0 || ds.lo >= 10*decimalBase {
+		var remainder uint64
+		expDiff := int16(ds.numDecimalDigits()) - 16
+		dp.exp += expDiff
+		remainder = ds.divrem64(ds, tenToThe[expDiff])
+		rndStatus = roundStatus(remainder, expDiff)
+	}
+	return rndStatus
+}
+
+func (dp *decParts) isZero() bool {
+	return dp.significand == uint128T{} && dp.fl.normal()
+}
+
+func (dp *decParts) isSubnormal() bool {
+	return (dp.significand != uint128T{}) && dp.significand.lo < decimalBase && dp.fl.normal()
+}
+
+// separation gets the separation in decimal places of the MSD's of two decimal 64s
+func (dp *decParts) separation(ep *decParts) int16 {
+	sep := int16(dp.significand.numDecimalDigits()) + dp.exp
+	sep -= int16(ep.significand.numDecimalDigits()) + ep.exp
+	return sep
+}
+
+// removeZeros removes zeros and increments the exponent to match.
+func (dp *decParts) removeZeros() {
+	e := dp.exp
+	n := dp.significand.lo
+	b := n / 1_0000_0000_0000_0000
+	if n == b*1_0000_0000_0000_0000 {
+		e += 16
+		n = b
+	}
+	b = n / 1_0000_0000
+	if n == b*1_0000_0000 {
+		e += 8
+		n = b
+	}
+	b = n / 10000
+	if n == b*10000 {
+		e += 4
+		n = b
+	}
+	b = n / 100
+	if n == b*100 {
+		e += 2
+		n = b
+	}
+	b = n / 10
+	if n == b*10 {
+		e++
+		n = b
+	}
+	dp.significand.lo = n
+	dp.exp = e
+}
+
+// isinf returns true if the decimal is an infinty
+func (dp *decParts) isinf() bool {
+	return dp.fl == flInf
+}
+
+func (dp *decParts) rescale(targetExp int16) discardedDigit {
+	expDiff := targetExp - dp.exp
+	rndStatus := roundStatus(dp.significand.lo, expDiff)
+	if expDiff > int16(dp.significand.numDecimalDigits()) {
+		dp.significand.lo, dp.exp = 0, targetExp
+		return rndStatus
+	}
+	divisor := tenToThe[expDiff]
+	dp.significand.lo = dp.significand.lo / divisor
+	dp.exp = targetExp
+	return rndStatus
+}
+
+func (dp *decParts) unpack(d Decimal) {
+	dp.fl = d.flavor()
+	dp.unpackV2(d)
+}
+
+func (dp *decParts) unpackV2(d Decimal) {
+	dp.sign = int8(d.bits >> 63)
+	switch dp.fl {
+	case flNormal53:
+		// s EEeeeeeeee   (0)ttt tttttttttt tttttttttt tttttttttt tttttttttt tttttttttt
+		//   EE ∈ {00, 01, 10}
+		dp.exp = int16((d.bits>>(63-10))&(1<<10-1)) - expOffset
+		dp.significand.lo = d.bits & (1<<53 - 1)
+	case flNormal51:
+		// s 11EEeeeeeeee (100)t tttttttttt tttttttttt tttttttttt tttttttttt tttttttttt
+		//     EE ∈ {00, 01, 10}
+		dp.exp = int16((d.bits>>(63-12))&(1<<10-1)) - expOffset
+		dp.significand.lo = d.bits&(1<<51-1) | (1 << 53)
+	case flInf:
+	default: // NaN
+		dp.significand.lo = d.bits & (1<<51 - 1) // Payload
+	}
+}
+
+// https://en.wikipedia.org/wiki/Decimal64_floating-point_format#Binary_integer_significand_field
+var flavMap = [...]flavor{
+	/* 0000xx */ flNormal53, flNormal53, flNormal53, flNormal53,
+	/* 0001xx */ flNormal53, flNormal53, flNormal53, flNormal53,
+	/* 0010xx */ flNormal53, flNormal53, flNormal53, flNormal53,
+	/* 0011xx */ flNormal53, flNormal53, flNormal53, flNormal53,
+	/* 0100xx */ flNormal53, flNormal53, flNormal53, flNormal53,
+	/* 0101xx */ flNormal53, flNormal53, flNormal53, flNormal53,
+	/* 0110xx */ flNormal53, flNormal53, flNormal53, flNormal53,
+	/* 0111xx */ flNormal53, flNormal53, flNormal53, flNormal53,
+	/* 1000xx */ flNormal53, flNormal53, flNormal53, flNormal53,
+	/* 1001xx */ flNormal53, flNormal53, flNormal53, flNormal53,
+	/* 1010xx */ flNormal53, flNormal53, flNormal53, flNormal53,
+	/* 1011xx */ flNormal53, flNormal53, flNormal53, flNormal53,
+	/* 1100xx */ flNormal51, flNormal51, flNormal51, flNormal51,
+	/* 1101xx */ flNormal51, flNormal51, flNormal51, flNormal51,
+	/* 1110xx */ flNormal51, flNormal51, flNormal51, flNormal51,
+	/* 11110x */ flInf, flInf,
+	/* 111110 */ flQNaN,
+	/* 111111 */ flSNaN,
+}
+
+func (d Decimal) flavor() flavor {
+	return flavMap[int(d.bits>>(64-7))%len(flavMap)]
+}

--- a/d64/decParts_test.go
+++ b/d64/decParts_test.go
@@ -1,0 +1,40 @@
+package d64
+
+import "testing"
+
+func TestPartsInf(t *testing.T) {
+	t.Parallel()
+
+	var a decParts
+	a.unpack(Inf)
+	check(t, a.fl == flInf)
+
+	a.unpack(NegInf)
+	check(t, a.fl == flInf)
+}
+
+func TestIsNaN(t *testing.T) {
+	t.Parallel()
+
+	var a decParts
+	a.unpack(Zero)
+	check(t, !a.fl.nan())
+
+	a.unpack(SNaN)
+	check(t, a.fl == flSNaN)
+}
+
+func TestPartsSubnormal(t *testing.T) {
+	t.Parallel()
+
+	d := MustParse("0.1E-383")
+	var subnormalParts decParts
+	subnormalParts.unpack(d)
+	check(t, subnormalParts.isSubnormal())
+
+	e := NewFromInt64(42)
+	var fortyTwoParts decParts
+	fortyTwoParts.unpack(e)
+	check(t, !fortyTwoParts.isSubnormal())
+
+}

--- a/d64/decimal.go
+++ b/d64/decimal.go
@@ -1,5 +1,4 @@
-// Deprecated: Use github.com/anz-bank/decimal/d64 instead.
-package decimal
+package d64
 
 import (
 	"fmt"
@@ -83,8 +82,8 @@ func (r Rounding) String() string {
 	}
 }
 
-// Context64 may be used to tune the behaviour of arithmetic operations.
-type Context64 struct {
+// Context may be used to tune the behaviour of arithmetic operations.
+type Context struct {
 	// Rounding sets the rounding behaviour of arithmetic operations.
 	Rounding Rounding
 
@@ -135,54 +134,54 @@ func (ctx Rounding) round(significand uint64, rndStatus discardedDigit) uint64 {
 	return significand
 }
 
-var ErrNaN64 error = Error("sNaN64")
+var ErrNaN error = Error("sNaN64")
 
-var small64s = []Decimal64{
-	new64str(newFromPartsRaw(1, -14, 1*decimal64Base).bits, "-10"),
+var smalls = []Decimal{
+	newStr(newFromPartsRaw(1, -14, 1*decimalBase).bits, "-10"),
 
-	new64str(newFromPartsRaw(1, -15, 9*decimal64Base).bits, "-9"),
-	new64str(newFromPartsRaw(1, -15, 8*decimal64Base).bits, "-8"),
-	new64str(newFromPartsRaw(1, -15, 7*decimal64Base).bits, "-7"),
-	new64str(newFromPartsRaw(1, -15, 6*decimal64Base).bits, "-6"),
-	new64str(newFromPartsRaw(1, -15, 5*decimal64Base).bits, "-5"),
-	new64str(newFromPartsRaw(1, -15, 4*decimal64Base).bits, "-4"),
-	new64str(newFromPartsRaw(1, -15, 3*decimal64Base).bits, "-3"),
-	new64str(newFromPartsRaw(1, -15, 2*decimal64Base).bits, "-2"),
-	new64str(newFromPartsRaw(1, -15, 1*decimal64Base).bits, "-1"),
+	newStr(newFromPartsRaw(1, -15, 9*decimalBase).bits, "-9"),
+	newStr(newFromPartsRaw(1, -15, 8*decimalBase).bits, "-8"),
+	newStr(newFromPartsRaw(1, -15, 7*decimalBase).bits, "-7"),
+	newStr(newFromPartsRaw(1, -15, 6*decimalBase).bits, "-6"),
+	newStr(newFromPartsRaw(1, -15, 5*decimalBase).bits, "-5"),
+	newStr(newFromPartsRaw(1, -15, 4*decimalBase).bits, "-4"),
+	newStr(newFromPartsRaw(1, -15, 3*decimalBase).bits, "-3"),
+	newStr(newFromPartsRaw(1, -15, 2*decimalBase).bits, "-2"),
+	newStr(newFromPartsRaw(1, -15, 1*decimalBase).bits, "-1"),
 
 	// TODO: Decimal64{}?
-	new64str(newFromPartsRaw(0, 0, 0).bits, "0"),
+	newStr(newFromPartsRaw(0, 0, 0).bits, "0"),
 
-	new64str(newFromPartsRaw(0, -15, 1*decimal64Base).bits, "1"),
-	new64str(newFromPartsRaw(0, -15, 2*decimal64Base).bits, "2"),
-	new64str(newFromPartsRaw(0, -15, 3*decimal64Base).bits, "3"),
-	new64str(newFromPartsRaw(0, -15, 4*decimal64Base).bits, "4"),
-	new64str(newFromPartsRaw(0, -15, 5*decimal64Base).bits, "5"),
-	new64str(newFromPartsRaw(0, -15, 6*decimal64Base).bits, "6"),
-	new64str(newFromPartsRaw(0, -15, 7*decimal64Base).bits, "7"),
-	new64str(newFromPartsRaw(0, -15, 8*decimal64Base).bits, "8"),
-	new64str(newFromPartsRaw(0, -15, 9*decimal64Base).bits, "9"),
+	newStr(newFromPartsRaw(0, -15, 1*decimalBase).bits, "1"),
+	newStr(newFromPartsRaw(0, -15, 2*decimalBase).bits, "2"),
+	newStr(newFromPartsRaw(0, -15, 3*decimalBase).bits, "3"),
+	newStr(newFromPartsRaw(0, -15, 4*decimalBase).bits, "4"),
+	newStr(newFromPartsRaw(0, -15, 5*decimalBase).bits, "5"),
+	newStr(newFromPartsRaw(0, -15, 6*decimalBase).bits, "6"),
+	newStr(newFromPartsRaw(0, -15, 7*decimalBase).bits, "7"),
+	newStr(newFromPartsRaw(0, -15, 8*decimalBase).bits, "8"),
+	newStr(newFromPartsRaw(0, -15, 9*decimalBase).bits, "9"),
 
-	new64str(newFromPartsRaw(0, -14, 1*decimal64Base).bits, "10"),
+	newStr(newFromPartsRaw(0, -14, 1*decimalBase).bits, "10"),
 }
 
-var small64Strings = func() map[uint64]string {
-	m := make(map[uint64]string, len(small64s))
+var smallStrings = func() map[uint64]string {
+	m := make(map[uint64]string, len(smalls))
 	for i := -10; i <= 10; i++ {
-		m[small64s[10+i].bits] = strconv.Itoa(i)
+		m[smalls[10+i].bits] = strconv.Itoa(i)
 	}
 	return m
 }()
 
-// New64FromInt64 returns a new Decimal64 with the given value.
-func New64FromInt64(i int64) Decimal64 {
+// NewFromInt64 returns a new [Decimal] with the given value.
+func NewFromInt64(i int64) Decimal {
 	if i >= -10 && i <= 10 {
-		return small64s[10+i]
+		return smalls[10+i]
 	}
-	return new64FromInt64(i)
+	return newFromInt64(i)
 }
 
-func new64FromInt64(value int64) Decimal64 {
+func newFromInt64(value int64) Decimal {
 	sign := int8(0)
 	if value < 0 {
 		sign = 1
@@ -213,9 +212,9 @@ func renormalize(exp int16, significand uint64) (int16, uint64) {
 		significand /= tenToThe[-normExp]
 	}
 	switch {
-	case significand < decimal64Base && exp > -expOffset:
+	case significand < decimalBase && exp > -expOffset:
 		return exp - 1, significand * 10
-	case significand >= 10*decimal64Base:
+	case significand >= 10*decimalBase:
 		return exp + 1, significand / 10
 	default:
 		return exp, significand
@@ -239,25 +238,25 @@ func roundStatus(significand uint64, expDiff int16) discardedDigit {
 	return gt5
 }
 
-func newFromParts(sign int8, exp int16, significand uint64) Decimal64 {
-	return new64(newFromPartsRaw(sign, exp, significand).bits)
+func newFromParts(sign int8, exp int16, significand uint64) Decimal {
+	return newDec(newFromPartsRaw(sign, exp, significand).bits)
 }
 
-func newFromPartsRaw(sign int8, exp int16, significand uint64) Decimal64 {
+func newFromPartsRaw(sign int8, exp int16, significand uint64) Decimal {
 	s := uint64(sign) << 63
 
 	if significand < 0x8<<50 {
 		// s EEeeeeeeee   (0)ttt tttttttttt tttttttttt tttttttttt tttttttttt tttttttttt
 		//   EE ∈ {00, 01, 10}
-		return Decimal64{bits: s | uint64(exp+expOffset)<<(63-10) | significand}
+		return Decimal{bits: s | uint64(exp+expOffset)<<(63-10) | significand}
 	}
 	// s 11EEeeeeeeee (100)t tttttttttt tttttttttt tttttttttt tttttttttt tttttttttt
 	//     EE ∈ {00, 01, 10}
 	significand &= 0x8<<50 - 1
-	return Decimal64{bits: s | uint64(0xc00|(exp+expOffset))<<(63-12) | significand}
+	return Decimal{bits: s | uint64(0xc00|(exp+expOffset))<<(63-12) | significand}
 }
 
-func (d Decimal64) parts() (fl flavor, sign int8, exp int16, significand uint64) {
+func (d Decimal) parts() (fl flavor, sign int8, exp int16, significand uint64) {
 	sign = int8(d.bits >> 63)
 	switch (d.bits >> (63 - 4)) & 0xf {
 	case 15:
@@ -322,14 +321,14 @@ func expWholeFrac(exp int16, significand uint64) (exp2 int16, whole uint64, frac
 	var whole128 uint128T
 	whole128.div10base(&n)
 	var x uint128T
-	x.mul64(&whole128, 10*decimal64Base)
+	x.mul64(&whole128, 10*decimalBase)
 	var frac128 uint128T
 	frac128.sub(&n, &x)
 	return exp, whole128.lo, frac128.lo
 }
 
 // Float64 returns a float64 representation of d.
-func (d Decimal64) Float64() float64 {
+func (d Decimal) Float64() float64 {
 	fl, sign, exp, significand := d.parts()
 	switch fl {
 	case flNormal53, flNormal51:
@@ -346,19 +345,19 @@ func (d Decimal64) Float64() float64 {
 	case flQNaN:
 		return math.NaN()
 	}
-	panic(ErrNaN64)
+	panic(ErrNaN)
 }
 
 // Int64 returns an int64 representation of d, clamped to [[math.MinInt64], [math.MaxInt64]].
-func (d Decimal64) Int64() int64 {
+func (d Decimal) Int64() int64 {
 	i, _ := d.Int64x()
 	return i
 }
 
-// Int64 returns an int64 representation of d, clamped to [[math.MinInt64],
+// Int64x returns an int64 representation of d, clamped to [[math.MinInt64],
 // [math.MaxInt64]].
-// The second return value, exact indicates whether New64FromInt64(i) == d.
-func (d Decimal64) Int64x() (i int64, exact bool) {
+// The second return value, exact, indicates whether [NewFromInt64](i) == d.
+func (d Decimal) Int64x() (i int64, exact bool) {
 	fl, sign, exp, significand := d.parts()
 	switch fl {
 	case flInf:
@@ -369,7 +368,7 @@ func (d Decimal64) Int64x() (i int64, exact bool) {
 	case flQNaN:
 		return 0, false
 	case flSNaN:
-		panic(ErrNaN64)
+		panic(ErrNaN)
 	}
 	exp, whole, frac := expWholeFrac(exp, significand)
 	for exp > 0 && whole < math.MaxInt64/10 {
@@ -382,34 +381,34 @@ func (d Decimal64) Int64x() (i int64, exact bool) {
 	return int64(1-2*sign) * int64(whole), frac == 0
 }
 
-// IsZero returns true if the Decimal encodes a zero value.
-func (d Decimal64) IsZero() bool {
+// IsZero returns true if the [Decimal] encodes a zero value.
+func (d Decimal) IsZero() bool {
 	fl, _, _, significand := d.parts()
 	return significand == 0 && fl.normal()
 }
 
 // IsInf indicates whether d is ±∞.
-func (d Decimal64) IsInf() bool {
+func (d Decimal) IsInf() bool {
 	return d.flavor() == flInf
 }
 
 // IsNaN indicates whether d is not a number.
-func (d Decimal64) IsNaN() bool {
+func (d Decimal) IsNaN() bool {
 	return d.flavor().nan()
 }
 
 // IsQNaN indicates whether d is a quiet NaN.
-func (d Decimal64) IsQNaN() bool {
+func (d Decimal) IsQNaN() bool {
 	return d.flavor() == flQNaN
 }
 
 // IsSNaN indicates whether d is a signalling NaN.
-func (d Decimal64) IsSNaN() bool {
+func (d Decimal) IsSNaN() bool {
 	return d.flavor() == flSNaN
 }
 
 // IsInt indicates whether d is an integer.
-func (d Decimal64) IsInt() bool {
+func (d Decimal) IsInt() bool {
 	fl, _, exp, significand := d.parts()
 	switch fl {
 	case flNormal53, flNormal51:
@@ -421,30 +420,30 @@ func (d Decimal64) IsInt() bool {
 }
 
 // quiet returns a quiet form of d, which must be a NaN.
-func (d Decimal64) quiet() Decimal64 {
-	return new64(d.bits &^ (2 << 56))
+func (d Decimal) quiet() Decimal {
+	return newDec(d.bits &^ (2 << 56))
 }
 
 // IsSubnormal indicates whether d is a subnormal.
-func (d Decimal64) IsSubnormal() bool {
+func (d Decimal) IsSubnormal() bool {
 	fl, _, _, significand := d.parts()
-	return significand != 0 && significand < decimal64Base && fl.normal()
+	return significand != 0 && significand < decimalBase && fl.normal()
 }
 
 // Sign returns -1/0/1 if d is </=/> 0, respectively.
-func (d Decimal64) Sign() int {
-	if d == Zero64 || d == NegZero64 {
+func (d Decimal) Sign() int {
+	if d == Zero || d == NegZero {
 		return 0
 	}
 	return 1 - 2*int(d.bits>>63)
 }
 
 // Signbit indicates whether d is negative or -0.
-func (d Decimal64) Signbit() bool {
+func (d Decimal) Signbit() bool {
 	return d.bits>>63 == 1
 }
 
-func (d Decimal64) ScaleB(e Decimal64) Decimal64 {
+func (d Decimal) ScaleB(e Decimal) Decimal {
 	var dp, ep decParts
 	if nan, is := checkNan(d, e, &dp, &ep); is {
 		return nan
@@ -454,17 +453,17 @@ func (d Decimal64) ScaleB(e Decimal64) Decimal64 {
 		return d
 	}
 	if !ep.fl.normal() {
-		return QNaN64
+		return QNaN
 	}
 
 	i, exact := e.Int64x()
 	if !exact {
-		return QNaN64
+		return QNaN
 	}
 	return scaleBInt(d, &dp, int(i))
 }
 
-func (d Decimal64) ScaleBInt(i int) Decimal64 {
+func (d Decimal) ScaleBInt(i int) Decimal {
 	var dp decParts
 	dp.unpack(d)
 	if !dp.fl.normal() || dp.isZero() {
@@ -473,28 +472,28 @@ func (d Decimal64) ScaleBInt(i int) Decimal64 {
 	return scaleBInt(d, &dp, i)
 }
 
-func scaleBInt(d Decimal64, dp *decParts, i int) Decimal64 {
+func scaleBInt(d Decimal, dp *decParts, i int) Decimal {
 	dp.exp += int16(i)
 
-	for dp.significand.lo < decimal64Base && dp.exp > -expOffset {
+	for dp.significand.lo < decimalBase && dp.exp > -expOffset {
 		dp.exp--
 		dp.significand.lo *= 10
 	}
 
 	switch {
 	case dp.exp > expMax:
-		return Infinity64.CopySign(d)
+		return Inf.CopySign(d)
 	case dp.exp < -expOffset:
 		for dp.exp < -expOffset {
 			dp.exp++
 			dp.significand.lo /= 10
 		}
 		if dp.significand.lo == 0 {
-			return Zero64.CopySign(d)
+			return Zero.CopySign(d)
 		}
 	}
 
-	return dp.decimal64()
+	return dp.decimal()
 }
 
 // Class returns a string representing the number's 'type' that the decimal is.
@@ -510,7 +509,7 @@ func scaleBInt(d Decimal64, dp *decParts, i int) Decimal64 {
 //   - "-Infinity"
 //   - "NaN"
 //   - "sNaN"
-func (d Decimal64) Class() string {
+func (d Decimal) Class() string {
 	var dp decParts
 	dp.unpack(d)
 	if dp.fl == flSNaN {
@@ -530,7 +529,7 @@ func (d Decimal64) Class() string {
 	return "+Normal-Normal"[7*dp.sign : 7*(dp.sign+1)]
 }
 
-func checkNan(d, e Decimal64, dp, ep *decParts) (Decimal64, bool) {
+func checkNan(d, e Decimal, dp, ep *decParts) (Decimal, bool) {
 	dp.fl = d.flavor()
 	ep.fl = e.flavor()
 	switch {
@@ -545,12 +544,12 @@ func checkNan(d, e Decimal64, dp, ep *decParts) (Decimal64, bool) {
 	default:
 		dp.unpackV2(d)
 		ep.unpackV2(e)
-		return Decimal64{}, false
+		return Decimal{}, false
 	}
 }
 
 // checkNan3 returns the decimal NaN that is to be propogated and true else first decimal and false
-func checkNan3(d, e, f Decimal64, dp, ep, fp *decParts) (Decimal64, bool) {
+func checkNan3(d, e, f Decimal, dp, ep, fp *decParts) (Decimal, bool) {
 	dp.fl = d.flavor()
 	ep.fl = e.flavor()
 	fp.fl = f.flavor()
@@ -571,6 +570,6 @@ func checkNan3(d, e, f Decimal64, dp, ep, fp *decParts) (Decimal64, bool) {
 		dp.unpackV2(d)
 		ep.unpackV2(e)
 		fp.unpackV2(f)
-		return Decimal64{}, false
+		return Decimal{}, false
 	}
 }

--- a/d64/decimalSuite_test.go
+++ b/d64/decimalSuite_test.go
@@ -1,0 +1,333 @@
+package d64
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+type opResult struct {
+	val1, val2, val3, result Decimal
+	text                     string
+}
+
+type testCase struct {
+	name           string
+	function       string
+	val1           string
+	val2           string
+	val3           string
+	expectedResult string
+	rounding       string
+}
+
+func (testVal *testCase) String() string {
+	if testVal == nil {
+		return "nil"
+	}
+	return fmt.Sprintf("%s %s (%v, %v, %v) -> %v", testVal.name, testVal.function, testVal.val1, testVal.val2, testVal.val3, testVal.expectedResult)
+}
+
+type set map[string]struct{}
+
+func (s set) Has(k string) bool {
+	_, ok := s[k]
+	return ok
+}
+
+var (
+	supportedRounding = set{"half_up": {}, "half_even": {}}
+	ignoredFunctions  = set{"apply": {}}
+	excludedTests     = set{
+		// ddintx074 and ddintx094 expect a specific bit pattern that doesn't
+		// seem to make sense
+		"ddintx074": {}, "ddintx094": {},
+	}
+)
+
+// TestFromSuite is the master tester for the dectest suite.
+func TestFromSuite(t *testing.T) {
+	t.Parallel()
+
+	test := func(file string) func(t *testing.T) {
+		return func(t *testing.T) {
+			t.Parallel()
+
+			f, _ := os.Open(file)
+			scanner := bufio.NewScanner(f)
+			numTests := 0
+			var roundingSupported bool
+			var scannedContext Context
+			for scanner.Scan() {
+				testVal := getInput(scanner.Text())
+				if testVal == nil {
+					continue
+				}
+				if testVal.rounding != "" {
+					roundingSupported = supportedRounding.Has(testVal.rounding)
+					if roundingSupported {
+						scannedContext = setRoundingFromString(testVal.rounding)
+					}
+				}
+				if testVal.function != "" && roundingSupported {
+					numTests++
+					t.Run(testVal.name, func(t *testing.T) {
+						decvals, err := convertToDec(testVal)
+						isnil(t, err)
+						if !runTest(t, scannedContext, decvals, testVal) {
+							runTest(t, scannedContext, decvals, testVal)
+						}
+					})
+				}
+			}
+		}
+	}
+
+	t.Run("ddAbs", test("dectest/ddAbs.decTest"))
+	t.Run("ddAdd", test("dectest/ddAdd.decTest"))
+	t.Run("ddClass", test("dectest/ddClass.decTest"))
+	t.Run("ddCompare", test("dectest/ddCompare.decTest"))
+	t.Run("ddCopySign", test("dectest/ddCopySign.decTest"))
+	t.Run("ddDivide", test("dectest/ddDivide.decTest"))
+	t.Run("ddFMA", test("dectest/ddFMA.decTest"))
+	t.Run("ddLogB", test("dectest/ddLogB.decTest"))
+	t.Run("ddMax", test("dectest/ddMax.decTest"))
+	t.Run("ddMaxMag", test("dectest/ddMaxMag.decTest"))
+	t.Run("ddMin", test("dectest/ddMin.decTest"))
+	t.Run("ddMinMag", test("dectest/ddMinMag.decTest"))
+	t.Run("ddMinus", test("dectest/ddMinus.decTest"))
+	t.Run("ddMultiply", test("dectest/ddMultiply.decTest"))
+	t.Run("ddNextMinus", test("dectest/ddNextMinus.decTest"))
+	t.Run("ddNextPlus", test("dectest/ddNextPlus.decTest"))
+	t.Run("ddPlus", test("dectest/ddPlus.decTest"))
+	t.Run("ddRound", test("dectest/ddRound.decTest"))
+	t.Run("ddScaleB", test("dectest/ddScaleB.decTest"))
+	t.Run("ddSubtract", test("dectest/ddSubtract.decTest"))
+	t.Run("ddToIntegral", test("dectest/ddToIntegral.decTest"))
+	t.Run("squareroot", test("dectest/squareroot.decTest"))
+
+	// Future
+	// t.Run("ddBase", test("dectest/ddBase.decTest"))
+	// t.Run("ddCompareTotal", test("dectest/ddCompareTotal.decTest"))
+	// t.Run("ddCompareTotalMag", test("dectest/ddCompareTotalMag.decTest"))
+	// t.Run("ddCopyAbs.decTest", //", test("dectest/ddCopyAbs.decTest", // QAb)s)
+	// t.Run("ddCopyNegate.decTest", //", test("dectest/ddCopyNegate.decTest", // QNe)g)
+	// t.Run("ddDivideInt", test("dectest/ddDivideInt.decTest"))
+	// t.Run("ddNextToward", test("dectest/ddNextToward.decTest"))
+	// t.Run("ddRemainder", test("dectest/ddRemainder.decTest"))
+	// t.Run("ddRemainderNear", test("dectest/ddRemainderNear.decTest"))
+
+	// Wat?
+	// t.Run("ddEncode", test("dectest/ddEncode.decTest"))
+
+	// Not planned
+	// -- bitwise
+	// t.Run("ddAnd", test("dectest/ddAnd.decTest"))
+	// t.Run("ddInvert", test("dectest/ddInvert.decTest"))
+	// t.Run("ddOr", test("dectest/ddOr.decTest"))
+	// t.Run("ddRotate", test("dectest/ddRotate.decTest"))
+	// t.Run("ddShift", test("dectest/ddShift.decTest"))
+	// t.Run("ddXor", test("dectest/ddXor.decTest"))
+	//
+	// -- signalling
+	// t.Run("ddCompareSig", test("dectest/ddCompareSig.decTest"))
+	//
+	// -- nop
+	// t.Run("ddCopy", test("dectest/ddCopy.decTest"))
+	//
+	// -- repr
+	// t.Run("ddCanonical", test("dectest/ddCanonical.decTest"))
+	// t.Run("ddQuantize", test("dectest/ddQuantize.decTest"))
+	// t.Run("ddReduce", test("dectest/ddReduce.decTest"))
+	// t.Run("ddSameQuantum", test("dectest/ddSameQuantum.decTest"))
+
+}
+
+func setRoundingFromString(s string) Context {
+	switch s {
+	case "half_even":
+		return Context{HalfEven}
+	case "half_up":
+		return Context{HalfUp}
+	case "default":
+		return DefaultContext
+	default:
+		panic("Rounding not supported" + s)
+	}
+}
+
+var (
+	testRegex     = regexp.MustCompile(`'((?:''+|[^'])*)'|(\S+)`)
+	roundingRegex = regexp.MustCompile(`(?:rounding:[\s]*)(?P<rounding>[\S]*)`)
+)
+
+// getInput gets the test file and extracts test using regex, then returns a map object and a list of test names.
+func getInput(line string) *testCase {
+	// TODO: Figure out what this comment means.
+	// Add regex to match to  rounding: rounding mode here
+
+	m := testRegex.FindAllStringSubmatch(line, -1)
+	if m == nil || !strings.HasPrefix(m[0][2], "dd") && !strings.HasPrefix(m[0][2], "sqtx") {
+		m := roundingRegex.FindStringSubmatch(line)
+		if m == nil {
+			return nil
+		}
+		return &testCase{rounding: m[1]}
+	}
+	fields := make([]string, 0, len(m))
+	for _, f := range m {
+		fields = append(fields, strings.ReplaceAll(f[1], "''", "'")+f[2])
+	}
+	i := 0
+	for ; i < len(fields); i++ {
+		if fields[i] == "->" {
+			break
+		}
+	}
+	if i == len(fields) {
+		panic("missing ->")
+	}
+	if i < 5 {
+		if i == -1 {
+			panic(fmt.Errorf("malformed input: %s", line))
+		}
+		head, tail := fields[:i], fields[i:]
+		for ; i < 5; i++ {
+			head = append(append([]string{}, head...), "")
+		}
+		fields = append(head, tail...)
+	}
+	test := &testCase{
+		name:           fields[0],
+		function:       fields[1],
+		val1:           fields[2],
+		val2:           fields[3],
+		val3:           fields[4],
+		expectedResult: fields[6], // field[6] == "->"
+	}
+	if excludedTests.Has(test.name) {
+		return nil
+	}
+	if ignoredFunctions.Has(test.function) {
+		return nil
+	}
+
+	// # represents a null value, which isn't meaningful for [Decimal].
+	if test.val1 == "#" || test.val2 == "#" {
+		return nil
+	}
+
+	return test
+}
+
+// convertToDec converts the map object strings to decimals.
+func convertToDec(testvals *testCase) (opResult, error) {
+	var r opResult
+	var err error
+	parseNotEmpty := func(s string) (Decimal, error) {
+		if s == "" {
+			return QNaN, nil
+		}
+		if hexBits, cut := strings.CutPrefix(s, "#"); cut {
+			bits, err := strconv.ParseUint(hexBits, 16, 64)
+			if err != nil {
+				return Decimal{}, err
+			}
+			return newDec(bits), nil
+		}
+		return Parse(s)
+	}
+	r.val1, err = parseNotEmpty(testvals.val1)
+	if err != nil {
+		return opResult{}, fmt.Errorf("error parsing val1: %w", err)
+	}
+	r.val2, err = parseNotEmpty(testvals.val2)
+	if err != nil {
+		return opResult{}, fmt.Errorf("error parsing val2: %w", err)
+	}
+	r.val3, err = parseNotEmpty(testvals.val3)
+	if err != nil {
+		return opResult{}, fmt.Errorf("error parsing val3: %w", err)
+	}
+	if textResults.Has(testvals.function) {
+		r.text = testvals.expectedResult
+	} else {
+		r.result, err = parseNotEmpty(testvals.expectedResult)
+		if err != nil {
+			return opResult{}, fmt.Errorf("error parsing expected: %w", err)
+		}
+	}
+	return r, nil
+}
+
+// runTest completes the tests and compares actual and expected results.
+func runTest(t *testing.T, context Context, expected opResult, testValStrings *testCase) pass {
+	return replayOnFail(t, func() {
+		actual := execOp(context, expected.val1, expected.val2, expected.val3, testValStrings.function)
+		switch {
+		case actual.text != "":
+			if testValStrings.function == "compare" && actual.text == "-2" && expected.result.IsNaN() {
+				return
+			}
+			if actual.text != testValStrings.expectedResult {
+				t.Errorf("test:\n%s\ncalculated text: %s", testValStrings, actual.text)
+			}
+		case actual.result.IsNaN() || expected.result.IsNaN():
+			e := expected.result.String()
+			a := actual.result.String()
+			if e != a {
+				t.Errorf("test:\n%s\ncalculated result: %v", testValStrings, actual.result)
+			}
+		case expected.result.Cmp(actual.result) != 0:
+			t.Errorf("test:\n%s\ncalculated result: %v", testValStrings, actual.result)
+		}
+	})
+}
+
+var textResults = set{"class": {}}
+
+var ops = map[string]func(ctx Context, a, b, c Decimal) any{
+	"add":         func(ctx Context, a, b, c Decimal) any { return ctx.Add(a, b) },
+	"abs":         func(ctx Context, a, b, c Decimal) any { return a.Abs() },
+	"class":       func(ctx Context, a, b, c Decimal) any { return a.Class() },
+	"compare":     func(ctx Context, a, b, c Decimal) any { return a.CmpDec(b) },
+	"copysign":    func(ctx Context, a, b, c Decimal) any { return a.CopySign(b) },
+	"divide":      func(ctx Context, a, b, c Decimal) any { return ctx.Quo(a, b) },
+	"fma":         func(ctx Context, a, b, c Decimal) any { return ctx.FMA(a, b, c) },
+	"logb":        func(ctx Context, a, b, c Decimal) any { return a.Logb() },
+	"max":         func(ctx Context, a, b, c Decimal) any { return a.Max(b) },
+	"maxmag":      func(ctx Context, a, b, c Decimal) any { return a.MaxMag(b) },
+	"min":         func(ctx Context, a, b, c Decimal) any { return a.Min(b) },
+	"minmag":      func(ctx Context, a, b, c Decimal) any { return a.MinMag(b) },
+	"minus":       func(ctx Context, a, b, c Decimal) any { return a.Neg() },
+	"multiply":    func(ctx Context, a, b, c Decimal) any { return ctx.Mul(a, b) },
+	"nextminus":   func(ctx Context, a, b, c Decimal) any { return a.NextMinus() },
+	"nextplus":    func(ctx Context, a, b, c Decimal) any { return a.NextPlus() },
+	"plus":        func(ctx Context, a, b, c Decimal) any { return a },
+	"scaleb":      func(ctx Context, a, b, c Decimal) any { return a.ScaleB(b) },
+	"round":       func(ctx Context, a, b, c Decimal) any { return ctx.Round(a, b) },
+	"tointegralx": func(ctx Context, a, b, c Decimal) any { return ctx.ToIntegral(a) },
+	"subtract":    func(ctx Context, a, b, c Decimal) any { return ctx.Add(a, b.Neg()) },
+	"squareroot":  func(ctx Context, a, b, c Decimal) any { return a.Sqrt() },
+	// "quantize":    func(ctx Context, a, b, c Decimal) any { return ctx.Quantize(a, b) },
+}
+
+// TODO: get runTest to run more functions such as FMA.
+// execOp returns the calculated answer to the operation as [Decimal].
+func execOp(ctx Context, a, b, c Decimal, op string) opResult {
+	if f, has := ops[op]; has {
+		switch a := f(ctx, a, b, c).(type) {
+		case string:
+			return opResult{text: a}
+		case Decimal:
+			return opResult{result: a}
+		default:
+			panic("wat?")
+		}
+	}
+	panic(fmt.Errorf("unhandled op: %s", op))
+}

--- a/d64/decimal_debug.go
+++ b/d64/decimal_debug.go
@@ -1,0 +1,54 @@
+//go:build decimal_debug
+// +build decimal_debug
+
+package d64
+
+import "fmt"
+
+// Decimal represents an IEEE 754 64-bit floating point decimal number.
+// It uses the binary representation method.
+// Decimal is intentionally a struct to ensure users don't accidentally cast it to uint64.
+type Decimal struct {
+	s           string
+	fl          flavor
+	sign        int8
+	exp         int16
+	significand uint64
+	bits        uint64
+}
+
+func newDec(bits uint64) Decimal {
+	d := newNostr(bits)
+	d.s = d.String()
+	return d
+}
+
+func newStr(bits uint64, s string) Decimal {
+	d := newNostr(bits)
+	d.s = s
+	return d
+}
+
+func newNostr(bits uint64) Decimal {
+	d := Decimal{bits: bits}
+
+	fl, sign, exp, significand := d.parts()
+
+	d.fl = fl
+	d.sign = sign
+	d.exp = exp
+	d.significand = significand
+	d.bits = d.bits
+
+	return d
+}
+
+func checkSignificandIsNormal(significand uint64) {
+	if decimalBase > significand {
+		panic(fmt.Errorf("Failed logic check: %d <= %d", decimalBase, significand))
+	}
+
+	if significand >= 10*decimalBase {
+		panic(fmt.Errorf("Failed logic check: %d < %d", significand, 10*decimalBase))
+	}
+}

--- a/d64/decimal_ndebug.go
+++ b/d64/decimal_ndebug.go
@@ -1,0 +1,25 @@
+//go:build !decimal_debug
+// +build !decimal_debug
+
+package d64
+
+// Decimal represents an IEEE 754 64-bit floating point decimal number.
+// It uses the binary representation method.
+// Decimal is intentionally a struct to ensure users don't accidentally cast it to uint64.
+type Decimal struct {
+	bits uint64
+}
+
+func newDec(bits uint64) Decimal {
+	return Decimal{bits: bits}
+}
+
+func newStr(bits uint64, _ string) Decimal {
+	return Decimal{bits: bits}
+}
+
+func newNostr(bits uint64) Decimal {
+	return Decimal{bits: bits}
+}
+
+func checkSignificandIsNormal(significand uint64) {}

--- a/d64/decimal_test.go
+++ b/d64/decimal_test.go
@@ -1,0 +1,325 @@
+package d64
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+func TestNewFromInt64(t *testing.T) {
+	t.Parallel()
+
+	for i := int64(0); i <= 1000; i++ {
+		replayOnFail(t, func() {
+			d := NewFromInt64(i)
+			j := d.Int64()
+			equal(t, i, j)
+		})
+		replayOnFail(t, func() {
+			d := NewFromInt64(-i)
+			j := d.Int64()
+			equal(t, -i, j)
+		})
+	}
+
+	// Test the neighborhood of powers of two up to the high-significand
+	// representation threshold.
+	for e := 4; e < 54; e++ {
+		base := int64(1) << uint(e)
+		for i := base - 10; i <= base+10; i++ {
+			replayOnFail(t, func() {
+				d := NewFromInt64(i)
+				j := d.Int64()
+				equal(t, i, j)
+			})
+		}
+	}
+}
+
+func TestNewFromInt64Big(t *testing.T) {
+	t.Parallel()
+
+	const limit = int64(decimalBase)
+	const step = limit / 997
+	for i := -int64(limit); i <= limit; i += step {
+		replayOnFail(t, func() {
+			d := NewFromInt64(i)
+			j := d.Int64()
+			equal(t, i, j)
+		})
+	}
+}
+
+func TestDecimalParse(t *testing.T) {
+	t.Parallel()
+
+	test := func(expected string, source string) {
+		t.Helper()
+		equal(t, strings.TrimSpace(expected), MustParse(source).String())
+	}
+
+	test("0", "0")
+	test("1e-13", "0.0000000000001")
+	test("1e-13", "1e-13")
+	test("1", "1")
+	test("100000", "100000")
+	test("1e+6", "1000000")
+}
+
+func TestDecimalParseHalfEvenOdd(t *testing.T) {
+	t.Parallel()
+
+	ctx := Context{Rounding: HalfEven}
+	test := func(expected string, source string) {
+		t.Helper()
+		equal(t, strings.TrimSpace(expected), ctx.MustParse(source).String())
+	}
+
+	test("1.000000000000007    ", "1.000000000000007")
+	test("1.000000000000007    ", "1.0000000000000074999999")
+	test("1.000000000000008    ", "1.0000000000000075000000")
+	test("1.000000000000008    ", "1.0000000000000075000001")
+
+	test("1.000000000000007e+11", "100000000000.0007")
+	test("1.000000000000007e+11", "100000000000.00074999999")
+	test("1.000000000000008e+11", "100000000000.00075000000")
+	test("1.000000000000008e+11", "100000000000.00075000001")
+}
+
+func TestDecimalParseHalfEvenEven(t *testing.T) {
+	t.Parallel()
+
+	ctx := Context{Rounding: HalfEven}
+	test := func(expected string, source string) {
+		t.Helper()
+		equal(t, strings.TrimSpace(expected), ctx.MustParse(source).String())
+	}
+
+	test("1.000000000000008    ", "1.000000000000008")
+	test("1.000000000000008    ", "1.0000000000000084999999")
+	test("1.000000000000008    ", "1.0000000000000085000000")
+	test("1.000000000000009    ", "1.0000000000000085000001")
+
+	test("1.000000000000008e+11", "100000000000.0008")
+	test("1.000000000000008e+11", "100000000000.00084999999")
+	test("1.000000000000008e+11", "100000000000.00085000000")
+	test("1.000000000000009e+11", "100000000000.00085000001")
+}
+
+func TestDecimalParseHalfUp(t *testing.T) {
+	t.Parallel()
+
+	ctx := Context{Rounding: HalfUp}
+	test := func(expected string, source string) {
+		t.Helper()
+		equal(t, strings.TrimSpace(expected), ctx.MustParse(source).String())
+	}
+
+	test("0", "0")
+	test("1e-13", "0.0000000000001")
+	test("1e-13", "1e-13")
+	test("1", "1")
+	test("100000", "100000")
+	test("1e+6", "1000000")
+
+	test("1.49999999999999 ", "1.49999999999999")
+	test("1.499999999999999", "1.499999999999999")
+	test("1.499999999999999", "1.4999999999999994999999")
+	test("1.5              ", "1.4999999999999995000000")
+	test("1.5              ", "1.4999999999999995000001")
+
+	test("1.99999999999949 ", "1.99999999999949")
+	test("1.999999999999499", "1.999999999999499")
+	test("1.999999999999499", "1.9999999999994994999999")
+	test("1.9999999999995  ", "1.9999999999994995000000")
+	test("1.9999999999995  ", "1.9999999999994995000001")
+
+	test("1.99999999999994 ", "1.99999999999994")
+	test("1.999999999999949", "1.999999999999949")
+	test("1.999999999999949", "1.9999999999999494999999")
+	test("1.99999999999995 ", "1.9999999999999495000000")
+	test("1.99999999999995 ", "1.9999999999999495000001")
+
+	test("10.4999999999999 ", "10.4999999999999")
+	test("10.49999999999999", "10.49999999999999")
+	test("10.49999999999999", "10.499999999999994999999")
+	test("10.5             ", "10.499999999999995000000")
+	test("10.5             ", "10.499999999999995000001")
+
+	test("1.00000000000499e+11 ", "100000000000.499")
+	test("1.000000000004999e+11", "100000000000.4999")
+	test("1.000000000005e+11   ", "100000000000.49999")
+}
+
+func TestDecimalParseDown(t *testing.T) {
+	t.Parallel()
+
+	ctx := Context{Rounding: Down}
+	test := func(expected string, source string) {
+		t.Helper()
+		equal(t, strings.TrimSpace(expected), ctx.MustParse(source).String())
+	}
+
+	test("0", "0")
+	test("1e-13", "0.0000000000001")
+	test("1e-13", "1e-13")
+	test("1", "1")
+	test("100000", "100000")
+	test("1e+6", "1000000")
+
+	test("1.49999999999999 ", "1.49999999999999")
+	test("1.499999999999999", "1.499999999999999")
+	test("1.499999999999999", "1.4999999999999994999999")
+	test("1.499999999999999", "1.4999999999999995000000")
+	test("1.499999999999999", "1.4999999999999995000001")
+
+	test("1.99999999999949 ", "1.99999999999949")
+	test("1.999999999999499", "1.999999999999499")
+	test("1.999999999999499", "1.9999999999994994999999")
+	test("1.999999999999499", "1.9999999999994995000000")
+	test("1.999999999999499", "1.9999999999994995000001")
+
+	test("1.99999999999994 ", "1.99999999999994")
+	test("1.999999999999949", "1.999999999999949")
+	test("1.999999999999949", "1.9999999999999494999999")
+	test("1.999999999999949", "1.9999999999999495000000")
+	test("1.999999999999949", "1.9999999999999495000001")
+
+	test("10.4999999999999 ", "10.4999999999999")
+	test("10.49999999999999", "10.49999999999999")
+	test("10.49999999999999", "10.499999999999994999999")
+	test("10.49999999999999", "10.499999999999995000000")
+	test("10.49999999999999", "10.499999999999995000001")
+
+	test("1.00000000000499e+11 ", "100000000000.499")
+	test("1.000000000004999e+11", "100000000000.4999")
+	test("1.000000000004999e+11", "100000000000.49999")
+}
+
+func TestDecimalFloat64(t *testing.T) {
+	t.Parallel()
+
+	equal(t, -1.0, NegOne.Float64())
+	equal(t, 0.0, Zero.Float64())
+	equal(t, 1.0, One.Float64())
+	equal(t, 10.0, NewFromInt64(10).Float64())
+
+	oneThird := One.Quo(NewFromInt64(3))
+	one := oneThird.Add(oneThird).Add(oneThird)
+	epsilon(t, oneThird.Float64(), 1.0/3.0)
+	epsilon(t, 1.0, one.Float64())
+
+	check(t, math.IsNaN(QNaN.Float64()))
+	panics(t, func() { SNaN.Float64() })
+	equal(t, math.Inf(1), Inf.Float64())
+	equal(t, math.Inf(-1), NegInf.Float64())
+}
+
+func TestDecimalInt64(t *testing.T) {
+	t.Parallel()
+
+	equal(t, -1, NegOne.Int64())
+	equal(t, 0, Zero.Int64())
+	equal(t, -0, NegZero.Int64())
+	equal(t, 1, One.Int64())
+	equal(t, 10, NewFromInt64(10).Int64())
+
+	equal(t, 0, QNaN.Int64())
+
+	equal(t, int64(math.MaxInt64), Inf.Int64())
+	equal(t, int64(math.MinInt64), NegInf.Int64())
+	equal(t, int64(math.MaxInt64), MustParse("1e100").Int64())
+	equal(t, int64(math.MaxInt64), MustParse("91234567890123456789e20").Int64())
+}
+
+func TestDecimal64IsInf(t *testing.T) {
+	t.Parallel()
+
+	check(t, Inf.IsInf())
+	check(t, NegInf.IsInf())
+
+	check(t, !Zero.IsInf())
+	check(t, !NegZero.IsInf())
+	check(t, !QNaN.IsInf())
+	check(t, !SNaN.IsInf())
+	check(t, !NewFromInt64(42).IsInf())
+	check(t, !NewFromInt64(-42).IsInf())
+}
+
+func TestDecimalIsNaN(t *testing.T) {
+	t.Parallel()
+
+	check(t, QNaN.IsNaN())
+	check(t, SNaN.IsNaN())
+
+	check(t, QNaN.IsQNaN())
+	check(t, !SNaN.IsQNaN())
+
+	check(t, !QNaN.IsSNaN())
+	check(t, SNaN.IsSNaN())
+
+	notNaN := func(n Decimal) {
+		check(t, !n.IsNaN())
+		check(t, !n.IsQNaN())
+		check(t, !n.IsSNaN())
+	}
+	notNaN(Inf)
+	notNaN(NegInf)
+	notNaN(Zero)
+	notNaN(NegZero)
+	notNaN(NewFromInt64(42))
+	notNaN(NewFromInt64(-42))
+
+}
+
+func TestDecimalIsInt(t *testing.T) {
+	t.Parallel()
+
+	fortyTwo := NewFromInt64(42)
+
+	check(t, Zero.IsInt())
+	check(t, fortyTwo.IsInt())
+	check(t, fortyTwo.Mul(fortyTwo).IsInt())
+	check(t, fortyTwo.Quo(fortyTwo).IsInt())
+	check(t, !One.Quo(fortyTwo).IsInt())
+
+	check(t, !Inf.IsInt())
+	check(t, !NegInf.IsInt())
+	check(t, !QNaN.IsInt())
+	check(t, !SNaN.IsInt())
+}
+
+func TestDecimalSign(t *testing.T) {
+	t.Parallel()
+
+	equal(t, 0, Zero.Sign())
+	equal(t, 0, NegZero.Sign())
+	equal(t, 1, One.Sign())
+	equal(t, -1, NegOne.Sign())
+}
+
+func TestDecimalSignbit(t *testing.T) {
+	t.Parallel()
+
+	check(t, !Zero.Signbit())
+	check(t, NegZero.Signbit())
+	check(t, !One.Signbit())
+	check(t, NegOne.Signbit())
+}
+
+func TestDecimalIsZero(t *testing.T) {
+	t.Parallel()
+
+	check(t, Zero.IsZero())
+	check(t, NegZero.IsZero())
+	check(t, !One.IsZero())
+}
+
+func TestIsSubnormal(t *testing.T) {
+	t.Parallel()
+
+	check(t, MustParse("0.1E-383").IsSubnormal())
+	check(t, MustParse("-0.1E-383").IsSubnormal())
+	check(t, !MustParse("NaN10").IsSubnormal())
+	check(t, !NewFromInt64(42).IsSubnormal())
+}

--- a/d64/error.go
+++ b/d64/error.go
@@ -1,0 +1,7 @@
+package d64
+
+type Error string
+
+func (e Error) Error() string {
+	return string(e)
+}

--- a/d64/flakyScanState_test.go
+++ b/d64/flakyScanState_test.go
@@ -1,0 +1,49 @@
+package d64
+
+import "fmt"
+
+type flakyScanState struct {
+	actual fmt.ScanState
+	offset int
+	failAt int
+}
+
+func (s *flakyScanState) ReadRune() (r rune, size int, err error) {
+	r, size, err = s.actual.ReadRune()
+	err = s.failNow(size, err)
+	return
+}
+
+func (s *flakyScanState) UnreadRune() error {
+	return s.actual.UnreadRune()
+}
+
+func (s *flakyScanState) SkipSpace() {
+	s.actual.SkipSpace()
+}
+
+func (s *flakyScanState) Token(skipSpace bool, f func(rune) bool) (token []byte, err error) {
+	token, err = s.actual.Token(skipSpace, f)
+	err = s.failNow(len(token), err)
+	return
+}
+
+func (s *flakyScanState) Width() (wid int, ok bool) {
+	return s.actual.Width()
+}
+
+func (s *flakyScanState) Read(buf []byte) (n int, err error) {
+	err = s.failNow(s.actual.Read(buf))
+	return
+}
+
+func (s *flakyScanState) failNow(size int, err error) error {
+	if err != nil {
+		return err
+	}
+	s.offset += size
+	if s.offset > s.failAt {
+		return fmt.Errorf("flakyScanState read failed")
+	}
+	return nil
+}

--- a/d64/fmt.go
+++ b/d64/fmt.go
@@ -1,0 +1,295 @@
+package d64
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+)
+
+var _ fmt.Formatter = Zero
+var _ fmt.Scanner = (*Decimal)(nil)
+var _ fmt.Stringer = Zero
+
+// DefaultFormatContext is the default context use for formatting [Decimal].
+// Unlike [DefaultContext], it uses HalfEven rounding to conform to standard
+// Go formatting for float types.
+var DefaultFormatContext = Context{Rounding: HalfEven}
+
+var zeros = [16]byte{
+	'0', '0', '0', '0', '0', '0', '0', '0',
+	'0', '0', '0', '0', '0', '0', '0', '0',
+}
+
+type appender struct {
+	wid     int
+	prec    int
+	flagger interface{ Flag(int) bool }
+}
+
+type noFlagsInt int
+
+var noFlags interface{ Flag(int) bool } = noFlagsInt(0)
+
+func (noFlagsInt) Flag(c int) bool {
+	return false
+}
+
+func appendZeros(buf []byte, n int) []byte {
+	if n <= 0 {
+		return buf
+	}
+	l := len(zeros)
+	for ; n > l; n -= l {
+		buf = append(buf, zeros[:]...)
+	}
+	return append(buf, zeros[:n]...)
+}
+
+func dotZeros(buf []byte, n int) []byte {
+	if n > 0 {
+		buf = append(buf, '.')
+		buf = appendZeros(buf, n)
+	}
+	return buf
+}
+
+func appendUint64(buf []byte, n, limit uint64) []byte {
+	// TODO: avoid dividing by a variable.
+	zeroPrefix := false
+	for limit > 0 {
+		msd := n / limit
+		if msd > 0 || zeroPrefix {
+			buf = append(buf, byte('0'+msd))
+			zeroPrefix = true
+		}
+		n -= limit * msd
+		limit /= 10
+	}
+	return buf
+}
+
+func (a *appender) uint64New(buf []byte, n uint64) []byte {
+	return strconv.AppendUint(buf, n, 10)
+}
+
+func appendFracF(buf []byte, n uint64, width, prec int) []byte {
+	if width > prec {
+		n /= tenToThe[width-prec]
+		width = prec
+	}
+	buf = formatBits10(buf, n%tenToThe[width], width)
+	return appendZeros(buf, prec-width)
+}
+
+func appendFracE(buf []byte, n uint64) []byte {
+	w := 15
+	for n%10 == 0 {
+		n /= 10
+		w--
+	}
+	return formatBits10(buf, n, w)
+}
+
+// Append appends the text representation of d to buf.
+func (d Decimal) Append(buf []byte, format byte, prec int) []byte {
+	return DefaultFormatContext.append(d, buf, -1, prec, noFlags, rune(format))
+}
+
+func precScale(prec int) Decimal {
+	return newDec(newFromPartsRaw(0, -15-max(0, int16(prec)), decimalBase).bits)
+}
+
+// Append appends the text representation of d to buf.
+func (ctx Context) append(
+	d Decimal,
+	buf []byte,
+	wid int,
+	prec int,
+	flagger interface{ Flag(int) bool },
+	verb rune,
+) []byte {
+	if buf == nil {
+		buf = make([]byte, 0, 32)
+	}
+	a := appender{wid, prec, flagger}
+
+	flav, sign, exp, significand := d.parts()
+	if sign == 1 {
+		buf = append(buf, '-')
+	}
+	switch flav {
+	case flQNaN, flSNaN:
+		buf = append(buf, []byte("NaN")...)
+		if significand != 0 {
+			return appendUint64(buf, significand, 10000)
+		}
+		return buf
+	case flInf:
+		return append(buf, []byte("inf")...)
+	}
+
+formatBlock:
+	switch verb {
+	case 'e', 'E':
+		exp, significand = unsubnormal(exp, significand)
+
+		whole := significand / decimalBase
+		buf = append(buf, byte('0'+whole))
+		frac := significand - decimalBase*whole
+		if frac > 0 {
+			buf = append(buf, '.')
+			buf = appendFracE(buf, frac)
+		}
+
+		if significand == 0 {
+			return buf
+		}
+
+		exp += 15
+		if exp != 0 {
+			buf = append(buf, byte(verb))
+			if exp < 0 {
+				buf = append(buf, '-')
+				exp = -exp
+			} else {
+				buf = append(buf, '+')
+			}
+			return appendUint64(buf, uint64(exp), 1000)
+		}
+		return buf
+	case 'f', 'F':
+		if 0 <= a.prec && a.prec <= 16 {
+			_, _, exp, significand = ctx.roundRaw(d, precScale(a.prec)).parts()
+		}
+
+		if significand == 0 {
+			buf = append(buf, '0')
+			return dotZeros(buf, a.prec)
+		}
+
+		exp, significand = unsubnormal(exp, significand)
+
+		// pure integer
+		if exp >= 0 {
+			buf = a.uint64New(buf, significand)
+			buf = appendZeros(buf, int(exp))
+			return dotZeros(buf, a.prec)
+		}
+
+		// integer part
+		fracDigits := int(min(-exp, 16))
+		unit := tenToThe[fracDigits]
+		buf = a.uint64New(buf, significand/unit)
+		buf = appendZeros(buf, int(exp))
+
+		// empty fractional part
+		if significand%unit == 0 {
+			return dotZeros(buf, a.prec)
+		}
+
+		buf = append(buf, '.')
+
+		// fractional part
+		prefix := int(max(0, -exp-16))
+		if a.prec < 0 {
+			buf = appendZeros(buf, prefix)
+			buf = appendFracF(buf, significand, fracDigits, 16)
+			buf = bytes.TrimRight(buf, "0")
+			return buf
+		}
+		buf = appendZeros(buf, min(a.prec, prefix))
+		return appendFracF(buf, significand, fracDigits, a.prec-prefix)
+	case 'g', 'G':
+		if exp < -decimalDigits-3 ||
+			a.prec >= 0 && int(exp) > a.prec ||
+			a.prec < 0 && exp > -decimalDigits+6 {
+			verb -= 'g' - 'e'
+		} else {
+			verb -= 'g' - 'f'
+		}
+		goto formatBlock
+	default:
+		return append(buf, '%', byte(verb))
+	}
+}
+
+// Format implements fmt.Formatter.
+func (d Decimal) Format(s fmt.State, verb rune) {
+	DefaultFormatContext.format(d, s, verb)
+}
+
+// format implements fmt.Formatter.
+func (ctx Context) format(d Decimal, s fmt.State, verb rune) {
+	prec := optInt(s.Precision())
+
+	switch verb {
+	case 'e', 'E', 'f', 'F':
+		if prec < 0 {
+			prec = 6
+		}
+	case 'g', 'G':
+	case 'v':
+		verb = 'g'
+	default:
+		fmt.Fprintf(s, "%%!%c(d64.Decimal=%s)", verb, d.String())
+		return
+	}
+
+	wid := optInt(s.Width())
+
+	s.Write(ctx.append(d, nil, wid, prec, s, verb)) //nolint:errcheck
+}
+
+func optInt(i int, has bool) int {
+	if has {
+		return i
+	}
+	return -1
+}
+
+// String returns a string representation of d.
+func (d Decimal) String() string {
+	return DefaultFormatContext.str(d)
+}
+
+func (ctx Context) str(d Decimal) string {
+	if s, has := smallStrings[d.bits]; has {
+		return s
+	}
+	return ctx.text(d, 'g', -1, -1)
+}
+
+// Text converts the floating-point number x to a string according to the given
+// format and precision prec.
+func (d Decimal) Text(format byte, prec int) string {
+	return DefaultFormatContext.text(d, rune(format), -1, prec)
+}
+
+func (ctx Context) text(d Decimal, verb rune, width, prec int) string {
+	var buf [32]byte
+	return string(ctx.append(d, buf[:0], width, prec, noFlags, verb))
+}
+
+// Contextual binds a [Decimal] to a [Context] for greater control of formatting.
+// It implements [fmt.Stringer] and [fmt.Formatter] on behalf of the number,
+// using the context to control formatting.
+type Contextual struct {
+	ctx Context
+	d   Decimal
+}
+
+func (c Contextual) String() string {
+	return c.ctx.str(c.d)
+}
+
+func (c Contextual) Format(s fmt.State, verb rune) {
+	c.ctx.format(c.d, s, verb)
+}
+
+func (c Contextual) Text(verb rune, width, prec int) string {
+	return c.ctx.text(c.d, verb, width, prec)
+}
+
+func (ctx Context) With(d Decimal) Contextual {
+	return Contextual{ctx, d}
+}

--- a/d64/fmt_test.go
+++ b/d64/fmt_test.go
@@ -1,0 +1,352 @@
+package d64
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestPrecScal(t *testing.T) {
+	t.Parallel()
+
+	test := func(s string, prec int) {
+		t.Helper()
+		expected := MustParse(s)
+		actual := newDec(precScale(prec).bits)
+		equal(t, expected, actual)
+	}
+
+	test("1", 0)
+	test("0.1", 1)
+	test("0.01", 2)
+	test("0.001", 3)
+	test("0.0001", 4)
+}
+
+func TestDecimalString(t *testing.T) {
+	t.Parallel()
+
+	equal(t, strconv.Itoa(0), NewFromInt64(0).String())
+	for i := int64(-1000); i <= 1000; i++ {
+		equal(t, strconv.Itoa(int(i)), NewFromInt64(i).String())
+	}
+
+	for f := 1; f < 1000; f += 11 {
+		fdigits := strings.TrimRight(fmt.Sprintf("%03d", f), "0")
+		fraction := NewFromInt64(int64(f)).Quo(NewFromInt64(1000))
+		for i := int64(0); i <= 100; i++ {
+			nopanic(t, func() {
+				equal(t,
+					strconv.Itoa(int(i))+"."+fdigits,
+					NewFromInt64(i).Add(fraction).String(),
+				)
+			})
+		}
+		for i := int64(-100); i < 0; i++ {
+			nopanic(t, func() {
+				equal(t,
+					strconv.Itoa(int(i))+"."+fdigits,
+					NewFromInt64(i).Sub(fraction).String(),
+				)
+			})
+		}
+	}
+}
+
+func TestDecimalStringEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	test := func(expected, source string) {
+		t.Helper()
+		equal(t, strings.TrimSpace(expected), MustParse(strings.TrimSpace(source)).String())
+	}
+	test(" 123456", "123456")
+	test("-123456", "-123456")
+	test(" 1.234567e+6", "1234567")
+	test("-1.234567e+6", "-1234567")
+	test(" 0.0001", "0.0001")
+	test("-0.0001", "-0.0001")
+	test(" 1e-5", "0.00001")
+	test("-1e-5", "-0.00001")
+	test(" 9.999999999999999e+384", "9.999999999999999e+384")
+	test("-9.999999999999999e+384", "-9.999999999999999e+384")
+	test(" 1e-398", " 1e-398")
+	test("-1e-398", "-1e-398")
+
+	// regression for prefix-zeros-after-dot bug
+	test("  1.666666666666667", "  1.666666666666667")
+	test("0.01666666666666667", "0.01666666666666667")
+}
+
+// Non-representative sample, but retained for comparison purposes.
+func BenchmarkIODecimalString(b *testing.B) {
+	d := NewFromInt64(123456789)
+	for i := 0; i <= b.N; i++ {
+		_ = d.String()
+	}
+}
+
+func BenchmarkIODecimalString2(b *testing.B) {
+	dd := []Decimal{
+		Zero,
+		Pi,
+		NewFromInt64(123456789),
+		MustParse("-12345678901234E-380"),
+		MustParse("+12345678901234E+380"),
+		QNaN,
+		Inf,
+	}
+	for i := 0; i <= b.N; i++ {
+		_ = dd[i%len(dd)].String()
+	}
+}
+
+func TestDecimalFormat(t *testing.T) {
+	t.Parallel()
+
+	for i := int64(-1000); i <= 1000; i++ {
+		equal(t, strconv.FormatInt(i, 10), fmt.Sprintf("%v", NewFromInt64(i)))
+	}
+
+	equal(t, "42", NewFromInt64(42).String())
+}
+
+func TestDecimalFormatNaN(t *testing.T) {
+	t.Parallel()
+
+	n := MustParse("-sNaN33")
+	equal(t, "-NaN33", n.String())
+}
+
+func TestDecimalFormatPrec(t *testing.T) {
+	t.Parallel()
+
+	pi := MustParse("3.1415926535897932384626433")
+
+	test := func(expected string, prec int, n Decimal) {
+		t.Helper()
+		var buf [32]byte
+		actual := string(DefaultFormatContext.append(n, buf[:0], -1, prec, noFlags, 'f'))
+		equal(t, expected, actual)
+		equal(t, expected, fmt.Sprintf("%.*f", prec, n))
+		equal(t, expected, n.Text('f', prec))
+	}
+
+	equal(t, "3.141592653589793", pi.String())
+	equal(t, "3.141592653589793", Context{Rounding: HalfEven}.With(pi).String())
+	equal(t, "3.141592653589793", Context{Rounding: HalfUp}.With(pi).String())
+	equal(t, "3.141592653589793", fmt.Sprintf("%v", pi))
+	equal(t, "3.141593", fmt.Sprintf("%f", pi))
+	equal(t, "%!q(d64.Decimal=3.141592653589793)", fmt.Sprintf("%q", pi))
+
+	test("3", 0, pi)
+	test("3.1", 1, pi)
+	test("3.14", 2, pi)
+	test("3.142", 3, pi)
+	test("3.141593", 6, pi)
+	test("3.141592654", 9, pi)
+	test("3.1415926536", 10, pi)
+	test("3.141592653589793", 15, pi)
+	test("3.14159265358979300000", 20, pi)
+	test("3.1415926535897930"+strings.Repeat("0", 64), 80, pi)
+	test("3.1415926535897930"+strings.Repeat("0", 100), 116, pi)
+
+	pi = pi.Add(NewFromInt64(100))
+	equal(t, "103.1415926535898", fmt.Sprintf("%v", pi))
+	equal(t, "103.141593", fmt.Sprintf("%f", pi))
+	test("103", 0, pi)
+	test("103.1", 1, pi)
+	test("103.14", 2, pi)
+	test("103.142", 3, pi)
+	test("103.141593", 6, pi)
+	test("103.141592654", 9, pi)
+	test("103.1415926536", 10, pi)
+	test("103.141592653589800", 15, pi)
+	test("103.14159265358980000000", 20, pi)
+	test("103.1415926535898000"+strings.Repeat("0", 64), 80, pi)
+	test("103.1415926535898000"+strings.Repeat("0", 100), 116, pi)
+
+	pi = pi.Add(NewFromInt64(100_000))
+	equal(t, "100103.1415926536", fmt.Sprintf("%v", pi))
+	equal(t, "100103.141593", fmt.Sprintf("%f", pi))
+	test("100103", 0, pi)
+	test("100103.1", 1, pi)
+	test("100103.14", 2, pi)
+	test("100103.142", 3, pi)
+	test("100103.141593", 6, pi)
+	test("100103.141592654", 9, pi)
+	test("100103.1415926536", 10, pi)
+	test("100103.141592653600000", 15, pi)
+	test("100103.14159265360000000000", 20, pi)
+	test("100103.1415926536000000"+strings.Repeat("0", 64), 80, pi)
+	test("100103.1415926536000000"+strings.Repeat("0", 100), 116, pi)
+
+	// // Add five digits to the significand so that we round at a 2.
+	pi = pi.Add(NewFromInt64(10_100_000_000))
+	equal(t, "1.010010010314159e+10", fmt.Sprintf("%v", pi))
+	equal(t, "10100100103.141590", fmt.Sprintf("%f", pi))
+	test("10100100103", 0, pi)
+	test("10100100103.1", 1, pi)
+	test("10100100103.14", 2, pi)
+	test("10100100103.142", 3, pi)
+	test("10100100103.141590", 6, pi)
+	test("10100100103.141590000", 9, pi)
+	test("10100100103.1415900000", 10, pi)
+	test("10100100103.141590000000000", 15, pi)
+	test("10100100103.14159000000000000000", 20, pi)
+	test("10100100103.1415900000000000"+strings.Repeat("0", 64), 80, pi)
+	test("10100100103.1415900000000000"+strings.Repeat("0", 100), 116, pi)
+}
+
+func TestDecimalFormatPrecEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	test := func(expected, input string) {
+		n, err := Parse(input)
+		isnil(t, err)
+		equal(t, expected, fmt.Sprintf("%.3f", n))
+	}
+
+	test("0.062", "0.0625")
+	test("0.063", "0.062500001")
+	test("0.062", "0.0625000000000000000000000000000000001")
+	test("-0.062", "-0.0625")
+	test("-0.063", "-0.062500001")
+	test("-0.062", "-0.0625000000000000000000000000000000001")
+	test("0.188", "0.1875")
+	test("0.188", "0.187500001")
+	test("0.188", "0.1875000000000000000000000000000000001")
+	test("-0.188", "-0.1875")
+	test("-0.188", "-0.187500001")
+	test("-0.188", "-0.1875000000000000000000000000000000001")
+}
+
+func TestDecimalFormatPrecEdgeCasesHalfUp(t *testing.T) {
+	t.Parallel()
+
+	ctx := Context{Rounding: HalfUp}
+	test := func(expected, input string) {
+		n, err := Parse(input)
+		isnil(t, err)
+		equal(t, expected, ctx.With(n).Text('f', -1, 3))
+		equal(t, expected, fmt.Sprintf("%.3f", ctx.With(n)))
+	}
+
+	test("0.063", "0.0625")
+	test("0.063", "0.062500001")
+	test("0.063", "0.0625000000000000000000000000000000001")
+	test("-0.063", "-0.0625")
+	test("-0.063", "-0.062500001")
+	test("-0.063", "-0.0625000000000000000000000000000000001")
+	test("0.188", "0.1875")
+	test("0.188", "0.187500001")
+	test("0.188", "0.1875000000000000000000000000000000001")
+	test("-0.188", "-0.1875")
+	test("-0.188", "-0.187500001")
+	test("-0.188", "-0.1875000000000000000000000000000000001")
+}
+
+func TestDecimalFormatPrecEdgeCases2(t *testing.T) {
+	t.Parallel()
+
+	test := func(expected string, input Decimal, prec int) {
+		t.Helper()
+		data := input.Append(nil, 'f', prec)
+		equal(t, expected, string(data))
+	}
+
+	test("10000.0000000000", MustParse("1e4"), 10)
+	test("10000000000.0000000000", MustParse("1e10"), 10)
+	test("100000000000.0000000000", MustParse("1e11"), 10)
+	test("100000000000000000000000000000000000000000000000000.0000000000", MustParse("1e50"), 10)
+	test("0.0001000000", MustParse("1e-4"), 10)
+	test("0.0000000001", MustParse("1e-10"), 10)
+	test("0.0000000000", MustParse("1e-11"), 10)
+	test("0.0000000000", MustParse("1e-20"), 10)
+	test("0.0000000000", MustParse("1e-30"), 10)
+	test("0.000000000000000000000000000001", MustParse("1e-30"), 30)
+	test("0.0000000000", Zero, 10)
+	test("-0.0000000000", Zero.NextMinus(), 10)
+	test("0.0000000000", Zero.NextPlus(), 10)
+	test("inf", Inf, 10)
+	test("9999999999999999000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.0000000000", Inf.NextMinus(), 10)
+	test("inf", Inf.NextPlus(), 10)
+
+	test("-10000.0000000000", MustParse("-1e4"), 10)
+	test("-10000000000.0000000000", MustParse("-1e10"), 10)
+	test("-100000000000.0000000000", MustParse("-1e11"), 10)
+	test("-100000000000000000000000000000000000000000000000000.0000000000", MustParse("-1e50"), 10)
+	test("-0.0001000000", MustParse("-1e-4"), 10)
+	test("-0.0000000001", MustParse("-1e-10"), 10)
+	test("-0.0000000000", MustParse("-1e-11"), 10)
+	test("-0.0000000000", MustParse("-1e-20"), 10)
+	test("-0.0000000000", MustParse("-1e-30"), 10)
+	test("-0.000000000000000000000000000001", MustParse("-1e-30"), 30)
+	test("-0.0000000000", NegZero, 10)
+	test("-0.0000000000", Zero.NextMinus(), 10)
+	test("0.0000000000", Zero.NextPlus(), 10)
+	test("-inf", NegInf, 10)
+	test("-inf", NegInf.NextMinus(), 10)
+	test("-9999999999999999000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.0000000000", NegInf.NextPlus(), 10)
+}
+
+func TestDecimalFormat2(t *testing.T) {
+	t.Parallel()
+
+	a := MustParse("0.0001643835616")
+	equal(t, "0.000164383562", fmt.Sprintf("%.12f", a))
+	b := NewFromInt64(600).Quo(NewFromInt64(10000))
+	b = b.Quo(NewFromInt64(365))
+	equal(t, "0.000164383562", fmt.Sprintf("%.12f", b))
+}
+
+func BenchmarkIODecimalFormat(b *testing.B) {
+	d := NewFromInt64(123456789)
+	for i := 0; i <= b.N; i++ {
+		_ = fmt.Sprintf("%v", d)
+	}
+}
+
+func TestDecimalAppend(t *testing.T) {
+	t.Parallel()
+
+	assertAppend := func(expected string, d Decimal, format byte, prec int) {
+		equal(t, expected, string(d.Append([]byte{}, format, prec)))
+	}
+
+	for i := int64(-1000); i <= 1000; i++ {
+		d := NewFromInt64(i)
+		f := d.Append([]byte{}, 'g', 0)
+		equal(t, strconv.FormatInt(i, 10), string(f))
+	}
+
+	assertAppend("NaN", QNaN, 'g', 0)
+	assertAppend("inf", Inf, 'g', 0)
+	assertAppend("-inf", NegInf, 'g', 0)
+	assertAppend("-0", NegZero, 'g', 0)
+	assertAppend("NaN", QNaN, 'f', 0)
+	assertAppend("NaN", SNaN, 'f', 0)
+	assertAppend("inf", Inf, 'f', 0)
+	assertAppend("-inf", NegInf, 'f', 0)
+	assertAppend("%w", Zero, 'w', 0)
+
+	assertAppend("1.23456789e+8", MustParse("123456789"), 'e', 0)
+	assertAppend("1.23456789e+18", MustParse("123456789e10"), 'e', 0)
+	assertAppend("1.23456789e-18", MustParse("123456789e-26"), 'e', 0)
+	assertAppend("1234567890000000000", MustParse("123456789e10"), 'f', 0)
+
+	assertAppend("123456789", MustParse("123456789"), 'g', 0)
+	assertAppend("1.23456789e+18", MustParse("123456789e10"), 'g', 0)
+	assertAppend("1.23456789e-18", MustParse("123456789e-26"), 'g', 0)
+	assertAppend("1.23456789e+18", MustParse("123456789e10"), 'g', 0)
+
+}
+
+func BenchmarkIODecimalAppend(b *testing.B) {
+	d := NewFromInt64(123456789)
+	var buf [32]byte
+	for i := 0; i <= b.N; i++ {
+		_ = d.Append(buf[:0], 'g', 0)
+	}
+}

--- a/d64/gob.go
+++ b/d64/gob.go
@@ -1,0 +1,18 @@
+package d64
+
+import (
+	"encoding/gob"
+)
+
+var _ gob.GobDecoder = (*Decimal)(nil)
+var _ gob.GobEncoder = Zero
+
+// GobDecode implements encoding.GobDecoder.
+func (d *Decimal) GobDecode(buf []byte) error {
+	return d.UnmarshalBinary(buf)
+}
+
+// GobEncode implements encoding.GobEncoder.
+func (d Decimal) GobEncode() ([]byte, error) {
+	return d.MarshalBinary()
+}

--- a/d64/gob_test.go
+++ b/d64/gob_test.go
@@ -1,0 +1,14 @@
+package d64
+
+import "testing"
+
+func TestDecimalGob(t *testing.T) {
+	t.Parallel()
+
+	gob, err := NewFromInt64(23456).GobEncode()
+	isnil(t, err)
+
+	var d Decimal
+	isnil(t, d.GobDecode(gob))
+	equal(t, NewFromInt64(23456), d)
+}

--- a/d64/itoa.go
+++ b/d64/itoa.go
@@ -1,0 +1,65 @@
+package d64
+
+const smallsString = "00010203040506070809" +
+	"10111213141516171819" +
+	"20212223242526272829" +
+	"30313233343536373839" +
+	"40414243444546474849" +
+	"50515253545556575859" +
+	"60616263646566676869" +
+	"70717273747576777879" +
+	"80818283848586878889" +
+	"90919293949596979899"
+
+const host32bit = ^uint(0)>>32 == 0
+
+// Adapted from standard library strconv/itoa.go.
+func formatBits10(buf []byte, u uint64, w int) []byte {
+	// Probably only needs 17, but let's play it safe.
+	var a [32]byte
+	i := len(a)
+
+	if host32bit {
+		// convert the lower digits using 32bit operations
+		for u >= 1e9 {
+			// Avoid using r = a%b in addition to q = a/b
+			// since 64bit division and modulo operations
+			// are calculated by runtime functions on 32bit machines.
+			q := u / 1e9
+			us := uint(u - q*1e9) // u % 1e9 fits into a uint
+			for j := 4; j > 0; j-- {
+				is := us % 100 * 2
+				us /= 100
+				i -= 2
+				w -= 2
+				a[i+1] = smallsString[is+1]
+				a[i+0] = smallsString[is+0]
+			}
+
+			// us < 10, since it contains the last digit
+			// from the initial 9-digit us.
+			i--
+			w--
+			a[i] = smallsString[us*2+1]
+
+			u = q
+		}
+		// u < 1e9
+	}
+
+	// u guaranteed to fit into a uint
+	us := uint(u)
+	for ; w > 0; w -= 2 {
+		is := us % 100 * 2
+		us /= 100
+		i -= 2
+		a[i+1] = smallsString[is+1]
+		a[i+0] = smallsString[is+0]
+	}
+
+	if w < 0 {
+		i++
+	}
+
+	return append(buf, a[i:]...)
+}

--- a/d64/json.go
+++ b/d64/json.go
@@ -1,0 +1,16 @@
+package d64
+
+import "encoding/json"
+
+var _ json.Marshaler = Zero
+var _ json.Unmarshaler = (*Decimal)(nil)
+
+// MarshalText implements the encoding.TextMarshaler interface.
+func (d Decimal) MarshalJSON() ([]byte, error) {
+	return d.MarshalText()
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (d *Decimal) UnmarshalJSON(data []byte) error {
+	return d.UnmarshalText(data)
+}

--- a/d64/json_test.go
+++ b/d64/json_test.go
@@ -1,0 +1,29 @@
+package d64
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestDecimalMarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	j, err := json.Marshal(MustParse("123.432"))
+	isnil(t, err)
+	equal(t, "123.432", string(j))
+}
+
+func TestDecimalUnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	var d Decimal
+	isnil(t, json.Unmarshal([]byte("23456"), &d))
+	equal(t, NewFromInt64(23456), d)
+}
+
+func TestDecimalUnmarshalBadInputJSON(t *testing.T) {
+	t.Parallel()
+
+	var d Decimal
+	notnil(t, json.Unmarshal([]byte("omg"), &d))
+}

--- a/d64/marshal.go
+++ b/d64/marshal.go
@@ -1,0 +1,51 @@
+package d64
+
+import (
+	"bytes"
+	"encoding"
+	"encoding/binary"
+	"fmt"
+)
+
+var _ encoding.TextMarshaler = Zero
+var _ encoding.TextUnmarshaler = (*Decimal)(nil)
+
+// MarshalText implements the encoding.TextMarshaler interface.
+func (d Decimal) MarshalText() ([]byte, error) {
+	return d.Append(nil, 'g', -1), nil
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (d *Decimal) UnmarshalText(text []byte) error {
+	state := &scanner{reader: bytes.NewReader(text)}
+	var e Decimal
+	if err := DefaultContext.Scan(&e, state, 'e'); err != nil {
+		return err
+	}
+
+	r, _, err := state.ReadRune()
+	if err == nil {
+		return fmt.Errorf("expected end of text, found %c", r)
+	}
+
+	*d = e
+	return nil
+}
+
+var _ encoding.BinaryMarshaler = Zero
+var _ encoding.BinaryUnmarshaler = (*Decimal)(nil)
+
+// MarshalBinary implements the encoding.BinaryMarshaler interface.
+func (d Decimal) MarshalBinary() ([]byte, error) {
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, d.bits)
+	return buf, nil
+}
+
+// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface.
+func (d *Decimal) UnmarshalBinary(data []byte) error {
+	bits := binary.BigEndian.Uint64(data)
+	// TODO: Check for out of bounds significand.
+	*d = newDec(bits)
+	return nil
+}

--- a/d64/marshal_test.go
+++ b/d64/marshal_test.go
@@ -1,0 +1,26 @@
+package d64
+
+import "testing"
+
+func TestDecimalMarshal(t *testing.T) {
+	t.Parallel()
+
+	data, err := NewFromInt64(23456).MarshalText()
+	isnil(t, err)
+	equal(t, "23456", string(data))
+}
+
+func TestDecimalUnmarshal(t *testing.T) {
+	t.Parallel()
+
+	var d Decimal
+	isnil(t, d.UnmarshalText([]byte("23456")))
+	equal(t, NewFromInt64(23456), d)
+}
+
+func TestDecimalUnmarshalBadInput(t *testing.T) {
+	t.Parallel()
+
+	var d Decimal
+	notnil(t, d.UnmarshalText([]byte("omg")))
+}

--- a/d64/math.go
+++ b/d64/math.go
@@ -1,0 +1,657 @@
+package d64
+
+import "math/bits"
+
+// Equal indicates whether two numbers are equal.
+// It is equivalent to d.Cmp(e) == 0.
+func (d Decimal) Equal(e Decimal) bool {
+	return d.Cmp(e) == 0
+}
+
+// Abs computes ||d||.
+func (d Decimal) Abs() Decimal {
+	if d.flavor().nan() {
+		return d
+	}
+	return d.abs()
+}
+
+func (d Decimal) abs() Decimal {
+	return newDec(^neg & uint64(d.bits))
+}
+
+// Add computes d + e.
+// It uses [DefaultContext] to call [Context.Add].
+func (d Decimal) Add(e Decimal) Decimal {
+	return DefaultContext.Add(d, e)
+}
+
+// FMA computes d × e + f.
+// It uses [DefaultContext] to call [Context.FMA].
+func (d Decimal) FMA(e, f Decimal) Decimal {
+	return DefaultContext.FMA(d, e, f)
+}
+
+// Mul computes d × e.
+// It uses [DefaultContext] to call [Context.Mul].
+func (d Decimal) Mul(e Decimal) Decimal {
+	return DefaultContext.Mul(d, e)
+}
+
+// Sub returns d - e.
+// It uses [DefaultContext] to call [Context.Sub].
+func (d Decimal) Sub(e Decimal) Decimal {
+	return DefaultContext.Sub(d, e)
+}
+
+// Quo computes d ÷ e.
+// It uses [DefaultContext] to call [Context.Quo].
+func (d Decimal) Quo(e Decimal) Decimal {
+	return DefaultContext.Quo(d, e)
+}
+
+// Cmp returns:
+//
+//	-2 if d or e is NaN
+//	-1 if d <  e
+//	 0 if d == e (incl. -0 == 0, -Inf == -Inf, and +Inf == +Inf)
+//	+1 if d >  e
+func (d Decimal) Cmp(e Decimal) int {
+	var dp, ep decParts
+	if _, nan := checkNan(d, e, &dp, &ep); nan {
+		return -2
+	}
+	return cmp(d, e, &dp, &ep)
+}
+
+// CmpDec is equivalent to Cmp but with a [Decimal] result.
+// If d or e is NaN, it returns a corresponding NaN result.
+func (d Decimal) CmpDec(e Decimal) Decimal {
+	var dp, ep decParts
+	if nan, is := checkNan(d, e, &dp, &ep); is {
+		return nan
+	}
+	switch cmp(d, e, &dp, &ep) {
+	case -1:
+		return NegOne
+	case 1:
+		return One
+	default:
+		return Zero
+	}
+}
+
+func cmp(d, e Decimal, dp, ep *decParts) int {
+	switch {
+	case d == e, dp.isZero() && ep.isZero():
+		return 0
+	default:
+		diff := d.Sub(e)
+		return 1 - 2*int(diff.bits>>63)
+	}
+}
+
+// Min returns the lower of d and e.
+func (d Decimal) Min(e Decimal) Decimal {
+	return d.min(e, 1)
+}
+
+// Max returns the lower of d and e.
+func (d Decimal) Max(e Decimal) Decimal {
+	return d.min(e, -1)
+}
+
+// Min returns the lower of d and e.
+func (d Decimal) min(e Decimal, sign int) Decimal {
+	var dp, ep decParts
+	dp.unpack(d)
+	ep.unpack(e)
+
+	dnan := dp.fl.nan()
+	enan := ep.fl.nan()
+
+	switch {
+	case !dnan && !enan: // Fast path for non-NaNs.
+		if sign*cmp(d, e, &dp, &ep) < 0 {
+			return d
+		}
+		return e
+
+	case dp.fl == flSNaN:
+		return d.quiet()
+	case ep.fl == flSNaN:
+		return e.quiet()
+
+	case !enan:
+		return e
+	default:
+		return d
+	}
+}
+
+// MinMag returns the lower of d and e.
+func (d Decimal) MinMag(e Decimal) Decimal {
+	return d.minMag(e, 1)
+}
+
+// MaxMag returns the lower of d and e.
+func (d Decimal) MaxMag(e Decimal) Decimal {
+	return d.minMag(e, -1)
+}
+
+// MinMag returns the lower of d and e.
+func (d Decimal) minMag(e Decimal, sign int) Decimal {
+	da, ea := d.abs(), e.abs()
+	var dp decParts
+	dp.unpack(da)
+	var ep decParts
+	ep.unpack(ea)
+
+	dnan := dp.fl.nan()
+	enan := ep.fl.nan()
+
+	switch {
+	case !dnan && !enan: // Fast path for non-NaNs.
+		switch sign * cmp(da, ea, &dp, &ep) {
+		case -1:
+			return d
+		case 1:
+			return e
+		default:
+			if 2*int(d.bits>>63) == 1+sign {
+				return d
+			}
+			return e
+		}
+	case dp.fl == flSNaN:
+		return d.quiet()
+	case ep.fl == flSNaN:
+		return e.quiet()
+	case !enan:
+		return e
+	default:
+		return d
+	}
+}
+
+// Neg computes -d.
+func (d Decimal) Neg() Decimal {
+	if d.flavor().nan() {
+		return d
+	}
+	return newDec(neg ^ d.bits)
+}
+
+// Logb return the integral log10 of d.
+func (d Decimal) Logb() Decimal {
+	fl := d.flavor()
+	switch {
+	case fl.nan():
+		return d
+	case d.IsZero():
+		return NegInf
+	case fl == flInf:
+		return Inf
+	default:
+		var dp decParts
+		dp.unpack(d)
+
+		// Adjust for subnormals.
+		e := dp.exp
+		for s := dp.significand.lo; s < decimalBase; s *= 10 {
+			e--
+		}
+
+		return NewFromInt64(int64(15 + e))
+	}
+}
+
+// CopySign copies d, but with the sign taken from e.
+func (d Decimal) CopySign(e Decimal) Decimal {
+	return newDec(d.bits&^neg | e.bits&neg)
+}
+
+// Quo computes d / e.
+// Rounding rules are applied as per the context.
+func (ctx Context) Quo(d, e Decimal) Decimal {
+	var dp, ep decParts
+	if nan, is := checkNan(d, e, &dp, &ep); is {
+		return nan
+	}
+	var ans decParts
+	ans.sign = dp.sign ^ ep.sign
+	if dp.isZero() {
+		if ep.isZero() {
+			return QNaN
+		}
+		return zeroes[ans.sign]
+	}
+	if dp.isinf() {
+		if ep.isinf() {
+			return QNaN
+		}
+		return infinities[ans.sign]
+	}
+	if ep.isinf() {
+		return zeroes[ans.sign]
+	}
+	if ep.isZero() {
+		return infinities[ans.sign]
+	}
+
+	const ampl = 1000
+	hi, lo := bits.Mul64(dp.significand.lo, ampl*decimalBase)
+	q, _ := bits.Div64(hi, lo, ep.significand.lo)
+	exp := dp.exp - ep.exp - 15
+
+	for q < ampl*decimalBase && exp > -expOffset {
+		q *= 10
+		exp--
+	}
+	for q >= 10*ampl*decimalBase {
+		q /= 10
+		exp++
+	}
+	for exp < -expOffset {
+		q /= 10
+		exp++
+	}
+	if exp > expMax {
+		return infinities[ans.sign]
+	}
+
+	switch ctx.Rounding {
+	case HalfUp:
+		q = (q + ampl/2) / ampl
+	case HalfEven:
+		d := q / ampl
+		rem := q - d*ampl
+		q = d
+		if rem > ampl/2 || rem == ampl/2 && d%2 == 1 {
+			q++
+		}
+	case Down:
+		q /= ampl
+	}
+
+	return newFromParts(ans.sign, exp, q)
+}
+
+// Sqrt computes √d.
+func (d Decimal) Sqrt() Decimal {
+	flav, sign, exp, significand := d.parts()
+	switch flav {
+	case flInf:
+		if sign == 1 {
+			return QNaN
+		}
+		return d
+	case flQNaN:
+		return d
+	case flSNaN:
+		return SNaN
+	case flNormal53, flNormal51:
+	}
+	if significand == 0 {
+		return d
+	}
+	if sign == 1 {
+		return QNaN
+	}
+	if exp&1 == 1 {
+		exp++
+		significand *= 10
+	} else {
+		significand *= 100
+	}
+	s := sqrtu64(significand) / 10
+	exp, significand = renormalize(exp/2, s)
+	return newFromParts(sign, exp, significand)
+}
+
+// Add computes d + e
+func (ctx Context) Add(d, e Decimal) Decimal {
+	var dp, ep decParts
+	if nan, is := checkNan(d, e, &dp, &ep); is {
+		return nan
+	}
+	if dp.fl == flInf || ep.fl == flInf {
+		if dp.fl != flInf {
+			return e
+		}
+		if ep.fl != flInf || ep.sign == dp.sign {
+			return d
+		}
+		return QNaN
+	}
+	return ctx.add(d, e, &dp, &ep)
+}
+
+// Add computes d + e
+func (ctx Context) add(d, e Decimal, dp, ep *decParts) Decimal {
+	if dp.significand.lo == 0 {
+		return e
+	} else if ep.significand.lo == 0 {
+		return d
+	}
+	sep := dp.exp - ep.exp
+
+	if sep < -17 {
+		return e
+	}
+	if sep < 0 {
+		dp, ep = ep, dp
+		sep = -sep
+	}
+	if sep > 17 {
+		return d
+	}
+	var rndStatus discardedDigit
+	var ans decParts
+	switch {
+	case sep == 0:
+		ans.add64(dp, ep)
+	case sep < 4:
+		dp.significand.lo *= tenToThe[sep]
+		dp.exp -= sep
+		ans.add64(dp, ep)
+	default:
+		dp.significand.mul64(&dp.significand, tenToThe[17])
+		dp.exp -= 17
+		ep.significand.mul64(&ep.significand, tenToThe[17-sep])
+		ep.exp -= 17 - sep
+		ans.add128V2(dp, ep)
+	}
+	rndStatus = ans.roundToLo()
+	if ans.exp < -expOffset {
+		rndStatus = ans.rescale(-expOffset)
+	}
+	ans.significand.lo = ctx.Rounding.round(ans.significand.lo, rndStatus)
+	if ans.significand.lo != 0 {
+		ans.exp, ans.significand.lo = renormalize(ans.exp, ans.significand.lo)
+	}
+	if ans.exp > expMax || ans.significand.lo > maxSig {
+		return infinities[ans.sign]
+	}
+	return ans.decimal()
+}
+
+// Add computes d + e
+func (ctx Context) Sub(d, e Decimal) Decimal {
+	return d.Add(newDec(neg ^ e.bits))
+}
+
+// FMA computes d*e + f
+func (ctx Context) FMA(d, e, f Decimal) Decimal {
+	var dp, ep, fp decParts
+	if nan, is := checkNan3(d, e, f, &dp, &ep, &fp); is {
+		return nan
+	}
+	var ans decParts
+	ans.sign = dp.sign ^ ep.sign
+	if dp.fl == flInf || ep.fl == flInf {
+		if fp.fl == flInf && ans.sign != fp.sign {
+			return QNaN
+		}
+		if ep.isZero() || dp.isZero() {
+			return QNaN
+		}
+		return infinities[ans.sign]
+	}
+	if ep.significand.lo == 0 || dp.significand.lo == 0 {
+		return f
+	}
+	if fp.fl == flInf {
+		return infinities[fp.sign]
+	}
+
+	var rndStatus discardedDigit
+	ep.removeZeros()
+	dp.removeZeros()
+	ans.exp = dp.exp + ep.exp
+	ans.significand.umul64(dp.significand.lo, ep.significand.lo)
+	sep := ans.separation(&fp)
+	if fp.significand.lo != 0 {
+		if sep < -17 {
+			return f
+		} else if sep <= 17 {
+			ans.add128(&ans, &fp)
+		}
+	}
+	rndStatus = ans.roundToLo()
+	if ans.exp < -expOffset {
+		rndStatus = ans.rescale(-expOffset)
+	}
+	ans.significand.lo = ctx.Rounding.round(ans.significand.lo, rndStatus)
+	if ans.exp >= -expOffset && ans.significand.lo != 0 {
+		ans.exp, ans.significand.lo = renormalize(ans.exp, ans.significand.lo)
+	}
+	if ans.exp > expMax || ans.significand.lo > maxSig {
+		return infinities[ans.sign]
+	}
+	return ans.decimal()
+}
+
+// Mul computes d * e.
+func (ctx Context) Mul(d, e Decimal) Decimal {
+	var dp, ep decParts
+	if nan, is := checkNan(d, e, &dp, &ep); is {
+		return nan
+	}
+	var ans decParts
+	ans.sign = dp.sign ^ ep.sign
+	if dp.fl == flInf || ep.fl == flInf {
+		if dp.isZero() || ep.isZero() {
+			return QNaN
+		}
+		return infinities[ans.sign]
+	}
+	return ctx.mul(&dp, &ep, &ans)
+}
+
+func (ctx Context) mul(dp, ep, ans *decParts) Decimal {
+	if ep.significand.lo == 0 || dp.significand.lo == 0 {
+		return zeroes[ans.sign]
+	}
+	var roundStatus discardedDigit
+	ans.significand.umul64(dp.significand.lo, ep.significand.lo)
+	ans.exp = dp.exp + ep.exp + 15
+	ans.significand.divbase(&ans.significand)
+	if ans.exp >= -expOffset {
+		ans.exp, ans.significand.lo = renormalize(ans.exp, ans.significand.lo)
+	} else if ans.exp < 1-expMax {
+		roundStatus = ans.rescale(-expOffset)
+	}
+	ans.significand.lo = ctx.Rounding.round(ans.significand.lo, roundStatus)
+	if ans.significand.lo > maxSig || ans.exp > expMax {
+		return infinities[ans.sign]
+	}
+	return ans.decimal()
+}
+
+// NextPlus returns the next value above d.
+func (d Decimal) NextPlus() Decimal {
+	flav, sign, exp, significand := d.parts()
+	switch {
+	case flav == flInf:
+		if sign == 1 {
+			return NegMax
+		}
+		return Inf
+	case !flav.normal():
+		return d
+	case significand == 0:
+		return Min
+	case sign == 1:
+		switch {
+		case significand > decimalBase:
+			return newDec(d.bits - 1)
+		case exp == -398:
+			if significand > 1 {
+				return newDec(d.bits - 1)
+			}
+			return Zero
+		default:
+			return newFromParts(sign, exp-1, 10*decimalBase-1)
+		}
+	default:
+		switch {
+		case significand < 10*decimalBase-1:
+			return newDec(d.bits + 1)
+		case exp == 369:
+			return Inf
+		default:
+			return newFromParts(sign, exp+1, decimalBase)
+		}
+	}
+}
+
+// NextMinus returns the next value above d.
+func (d Decimal) NextMinus() Decimal {
+	flav, sign, exp, significand := d.parts()
+	switch {
+	case flav == flInf:
+		if sign == 0 {
+			return Max
+		}
+		return NegInf
+	case !flav.normal():
+		return d
+	case significand == 0:
+		return NegMin
+	case sign == 0:
+		switch {
+		case significand > decimalBase:
+			return newDec(d.bits - 1)
+		case exp == -398:
+			if significand > 1 {
+				return newDec(d.bits - 1)
+			}
+			return Zero
+		default:
+			return newFromParts(sign, exp-1, 10*decimalBase-1)
+		}
+	default:
+		switch {
+		case significand < 10*decimalBase-1:
+			return newDec(d.bits + 1)
+		case exp == 369:
+			return NegInf
+		default:
+			return newFromParts(sign, exp+1, decimalBase)
+		}
+	}
+}
+
+// Round rounds a number to a given power-of-10 value.
+// The e argument should be a power of ten, such as 1, 10, 100, 1000, etc.
+// It uses [DefaultContext] to call [Context.Round].
+func (d Decimal) Round(e Decimal) Decimal {
+	return DefaultContext.Round(d, e)
+}
+
+// Round rounds a number to a given power of ten value.
+// The e argument should be a power of ten, such as 1, 10, 100, 1000, etc.
+func (ctx Context) Round(d, e Decimal) Decimal {
+	return newDec(ctx.roundRaw(d, e).bits)
+}
+
+func (ctx Context) roundRaw(d, e Decimal) Decimal {
+	var dp, ep decParts
+	return ctx.roundRefRaw(d, e, &dp, &ep)
+}
+
+var (
+	zeroRaw = newNostr(newFromPartsRaw(0, 0, 0).bits)
+	qNaNRaw = newNostr(0x7c << 56)
+)
+
+func (ctx Context) roundRefRaw(d, e Decimal, dp, ep *decParts) Decimal {
+	if nan, is := checkNan(d, e, dp, ep); is {
+		return nan
+	}
+	if dp.fl == flInf || ep.fl == flInf {
+		if dp.fl == flInf && ep.fl == flInf {
+			return d
+		}
+		return qNaNRaw
+	}
+
+	dexp, dsignificand := unsubnormal(dp.exp, dp.significand.lo)
+	eexp, _ := unsubnormal(ep.exp, ep.significand.lo)
+
+	delta := dexp - eexp
+	if delta < -1 { // -1 avoids rounding range
+		return zeroRaw
+	}
+	if delta > 14 {
+		return d
+	}
+	p := tenToThe[14-delta]
+	s, grew := ctx.round(dsignificand, p)
+	exp := dexp
+	if grew {
+		s /= 10
+		exp++ // Cannot max out because final digit never rounds up.
+	}
+	exp, s = resubnormal(exp, s)
+	return newFromPartsRaw(dp.sign, exp, s)
+}
+
+// ToIntegral rounds d to a nearby integer.
+// It uses [DefaultContext] to call [Context.ToIntegral].
+func (d Decimal) ToIntegral() Decimal {
+	return DefaultContext.ToIntegral(d)
+}
+
+var decPartsOne decParts = unpack(One)
+
+// ToIntegral rounds d to a nearby integer.
+func (ctx Context) ToIntegral(d Decimal) Decimal {
+	var dp decParts
+	dp.unpack(d)
+	if !dp.fl.normal() || dp.exp >= 0 {
+		return d
+	}
+	return newDec(ctx.roundRefRaw(d, One, &dp, &decPartsOne).bits)
+}
+
+func (ctx Context) round(s, p uint64) (uint64, bool) {
+	p5 := p * 5
+	p10 := p5 * 2
+	div := s / p10
+	rem := s - p10*div
+	if rem == 0 {
+		return s, false
+	}
+	s -= rem
+	up := false
+	switch ctx.Rounding {
+	case HalfUp:
+		up = rem >= p5
+	case HalfEven:
+		up = rem > p5 || rem == p5 && div%2 == 1
+	}
+	if up {
+		return s + p10, div == 0
+	}
+	return s, false
+}
+
+func unsubnormal(exp int16, significand uint64) (int16, uint64) {
+	if significand != 0 {
+		for significand < decimalBase {
+			significand *= 10
+			exp--
+		}
+	}
+	return exp, significand
+}
+
+func resubnormal(exp int16, significand uint64) (int16, uint64) {
+	for exp < -expOffset || significand >= 10*decimalBase {
+		significand /= 10
+		exp++
+	}
+	return exp, significand
+}

--- a/d64/math_test.go
+++ b/d64/math_test.go
@@ -1,4 +1,4 @@
-package decimal
+package d64
 
 import (
 	"fmt"
@@ -8,15 +8,15 @@ import (
 
 var sink any
 
-func checkDecimal64BinOp(
+func checkDecimalBinOp(
 	t *testing.T,
 	expected func(a, b int64) int64,
-	actual func(a, b Decimal64) Decimal64,
+	actual func(a, b Decimal) Decimal,
 ) {
 	for i := int64(-100); i <= 100; i++ {
-		a := New64FromInt64(i)
+		a := NewFromInt64(i)
 		for j := int64(-100); j <= 100; j++ {
-			b := New64FromInt64(j)
+			b := NewFromInt64(j)
 			c := actual(a, b)
 			k := c.Int64()
 			e := expected(i, j)
@@ -25,39 +25,39 @@ func checkDecimal64BinOp(
 	}
 }
 
-func TestDecimal64Abs(t *testing.T) {
+func TestDecimalAbs(t *testing.T) {
 	t.Parallel()
 
-	equal(t, Zero64, Zero64.Abs())
-	equal(t, Zero64, NegZero64.Abs())
-	equal(t, Infinity64, Infinity64.Abs())
-	equal(t, Infinity64, NegInfinity64.Abs())
+	equal(t, Zero, Zero.Abs())
+	equal(t, Zero, NegZero.Abs())
+	equal(t, Inf, Inf.Abs())
+	equal(t, Inf, NegInf.Abs())
 
-	fortyTwo := New64FromInt64(42)
+	fortyTwo := NewFromInt64(42)
 	equal(t, fortyTwo, fortyTwo.Abs())
-	equal(t, fortyTwo, New64FromInt64(-42).Abs())
+	equal(t, fortyTwo, NewFromInt64(-42).Abs())
 }
 
-func TestDecimal64Add(t *testing.T) {
+func TestDecimalAdd(t *testing.T) {
 	t.Parallel()
 
 	if testing.Short() {
-		t.Skip("skipping TestDecimal64Add in short mode.")
+		t.Skip("skipping TestDecimalAdd in short mode.")
 	}
-	checkDecimal64BinOp(t,
+	checkDecimalBinOp(t,
 		func(a, b int64) int64 { return a + b },
-		func(a, b Decimal64) Decimal64 { return a.Add(b) },
+		func(a, b Decimal) Decimal { return a.Add(b) },
 	)
 
-	add := func(a, b, expected string, ctx *Context64) func(*testing.T) {
+	add := func(a, b, expected string, ctx *Context) func(*testing.T) {
 		return func(*testing.T) {
 			t.Helper()
 
-			e := MustParse64(expected)
-			x := MustParse64(a)
-			y := MustParse64(b)
+			e := MustParse(expected)
+			x := MustParse(a)
+			y := MustParse(b)
 			if ctx == nil {
-				ctx = &DefaultContext64
+				ctx = &DefaultContext
 			}
 			replayOnFail(t, func() {
 				z := ctx.Add(x, y)
@@ -68,69 +68,69 @@ func TestDecimal64Add(t *testing.T) {
 
 	t.Run("tiny-neg", add("1E-383", "-1E-398", "9.99999999999999E-384", nil))
 
-	he := Context64{Rounding: HalfEven}
+	he := Context{Rounding: HalfEven}
 	t.Run("round-even", add("12345678", "0.123456785", "12345678.12345678", &he))
 }
 
-func TestDecimal64AddNaN(t *testing.T) {
+func TestDecimalAddNaN(t *testing.T) {
 	t.Parallel()
 
-	fortyTwo := New64FromInt64(42)
+	fortyTwo := NewFromInt64(42)
 
-	equal(t, QNaN64, fortyTwo.Add(QNaN64))
-	equal(t, QNaN64, QNaN64.Add(fortyTwo))
+	equal(t, QNaN, fortyTwo.Add(QNaN))
+	equal(t, QNaN, QNaN.Add(fortyTwo))
 }
 
-func TestDecimal64AddInf(t *testing.T) {
+func TestDecimalAddInf(t *testing.T) {
 	t.Parallel()
 
-	fortyTwo := New64FromInt64(42)
+	fortyTwo := NewFromInt64(42)
 
-	equal(t, Infinity64, fortyTwo.Add(Infinity64))
-	equal(t, Infinity64, Infinity64.Add(fortyTwo))
+	equal(t, Inf, fortyTwo.Add(Inf))
+	equal(t, Inf, Inf.Add(fortyTwo))
 
-	equal(t, NegInfinity64, fortyTwo.Add(NegInfinity64))
-	equal(t, NegInfinity64, NegInfinity64.Add(fortyTwo))
+	equal(t, NegInf, fortyTwo.Add(NegInf))
+	equal(t, NegInf, NegInf.Add(fortyTwo))
 
-	equal(t, Infinity64, Infinity64.Add(Infinity64))
-	equal(t, NegInfinity64, NegInfinity64.Add(NegInfinity64))
+	equal(t, Inf, Inf.Add(Inf))
+	equal(t, NegInf, NegInf.Add(NegInf))
 
-	equal(t, QNaN64, Infinity64.Add(NegInfinity64))
-	equal(t, QNaN64, NegInfinity64.Add(Infinity64))
+	equal(t, QNaN, Inf.Add(NegInf))
+	equal(t, QNaN, NegInf.Add(Inf))
 }
 
-func TestDecimal64Cmp(t *testing.T) {
+func TestDecimalCmp(t *testing.T) {
 	t.Parallel()
 
-	equal(t, 0, NegOne64.Cmp(NegOne64))
+	equal(t, 0, NegOne.Cmp(NegOne))
 
-	equal(t, 0, Zero64.Cmp(Zero64))
-	equal(t, 0, Zero64.Cmp(NegZero64))
-	equal(t, 0, NegZero64.Cmp(Zero64))
-	equal(t, 0, NegZero64.Cmp(NegZero64))
+	equal(t, 0, Zero.Cmp(Zero))
+	equal(t, 0, Zero.Cmp(NegZero))
+	equal(t, 0, NegZero.Cmp(Zero))
+	equal(t, 0, NegZero.Cmp(NegZero))
 
-	equal(t, 0, One64.Cmp(One64))
-	equal(t, -1, NegOne64.Cmp(Zero64))
-	equal(t, -1, NegOne64.Cmp(NegZero64))
-	equal(t, -1, NegOne64.Cmp(One64))
-	equal(t, -1, Zero64.Cmp(One64))
-	equal(t, -1, NegZero64.Cmp(One64))
-	equal(t, 1, Zero64.Cmp(NegOne64))
-	equal(t, 1, NegZero64.Cmp(NegOne64))
-	equal(t, 1, One64.Cmp(NegOne64))
-	equal(t, 1, One64.Cmp(Zero64))
-	equal(t, 1, One64.Cmp(NegZero64))
+	equal(t, 0, One.Cmp(One))
+	equal(t, -1, NegOne.Cmp(Zero))
+	equal(t, -1, NegOne.Cmp(NegZero))
+	equal(t, -1, NegOne.Cmp(One))
+	equal(t, -1, Zero.Cmp(One))
+	equal(t, -1, NegZero.Cmp(One))
+	equal(t, 1, Zero.Cmp(NegOne))
+	equal(t, 1, NegZero.Cmp(NegOne))
+	equal(t, 1, One.Cmp(NegOne))
+	equal(t, 1, One.Cmp(Zero))
+	equal(t, 1, One.Cmp(NegZero))
 }
 
-func TestDecimal64CmpNaN(t *testing.T) {
+func TestDecimalCmpNaN(t *testing.T) {
 	t.Parallel()
 
-	equal(t, -2, QNaN64.Cmp(QNaN64))
-	equal(t, -2, Zero64.Cmp(QNaN64))
-	equal(t, -2, QNaN64.Cmp(Zero64))
+	equal(t, -2, QNaN.Cmp(QNaN))
+	equal(t, -2, Zero.Cmp(QNaN))
+	equal(t, -2, QNaN.Cmp(Zero))
 }
 
-func TestDecimal64MulThreeByOneTenthByTen(t *testing.T) {
+func TestDecimalMulThreeByOneTenthByTen(t *testing.T) {
 	t.Parallel()
 
 	// float 3*0.1*10 ≠ 3
@@ -143,73 +143,73 @@ func TestDecimal64MulThreeByOneTenthByTen(t *testing.T) {
 	notequal(t, fltThree, fltProduct)
 
 	// decimal 3*0.1*10 = 3
-	decThree := New64FromInt64(3)
-	decTen := New64FromInt64(10)
-	decOne := New64FromInt64(1)
+	decThree := NewFromInt64(3)
+	decTen := NewFromInt64(10)
+	decOne := NewFromInt64(1)
 	decOneTenth := decOne.Quo(decTen)
 	decProduct := decThree.Mul(decOneTenth).Mul(decTen)
 	equalD64(t, decTen.Mul(decOneTenth), decOne)
 	equalD64(t, decThree, decProduct)
 }
 
-func TestDecimal64Mul(t *testing.T) {
+func TestDecimalMul(t *testing.T) {
 	t.Parallel()
 
 	if testing.Short() {
-		t.Skip("skipping TestDecimal64Mul in short mode.")
+		t.Skip("skipping TestDecimalMul in short mode.")
 	}
-	checkDecimal64BinOp(t,
+	checkDecimalBinOp(t,
 		func(a, b int64) int64 { return a * b },
-		func(a, b Decimal64) Decimal64 { return a.Mul(b) },
+		func(a, b Decimal) Decimal { return a.Mul(b) },
 	)
 }
 
-func TestDecimal64MulNaN(t *testing.T) {
+func TestDecimalMulNaN(t *testing.T) {
 	t.Parallel()
 
-	fortyTwo := New64FromInt64(42)
+	fortyTwo := NewFromInt64(42)
 
-	equal(t, QNaN64, fortyTwo.Mul(QNaN64))
-	equal(t, QNaN64, QNaN64.Mul(fortyTwo))
+	equal(t, QNaN, fortyTwo.Mul(QNaN))
+	equal(t, QNaN, QNaN.Mul(fortyTwo))
 }
 
-func TestDecimal64MulInf(t *testing.T) {
+func TestDecimalMulInf(t *testing.T) {
 	t.Parallel()
 
-	fortyTwo := New64FromInt64(42)
-	negFortyTwo := New64FromInt64(-42)
+	fortyTwo := NewFromInt64(42)
+	negFortyTwo := NewFromInt64(-42)
 
-	equal(t, Infinity64, fortyTwo.Mul(Infinity64))
-	equal(t, Infinity64, Infinity64.Mul(fortyTwo))
-	equal(t, NegInfinity64, negFortyTwo.Mul(Infinity64))
-	equal(t, NegInfinity64, Infinity64.Mul(negFortyTwo))
+	equal(t, Inf, fortyTwo.Mul(Inf))
+	equal(t, Inf, Inf.Mul(fortyTwo))
+	equal(t, NegInf, negFortyTwo.Mul(Inf))
+	equal(t, NegInf, Inf.Mul(negFortyTwo))
 
-	equal(t, NegInfinity64, fortyTwo.Mul(NegInfinity64))
-	equal(t, NegInfinity64, NegInfinity64.Mul(fortyTwo))
-	equal(t, Infinity64, negFortyTwo.Mul(NegInfinity64))
-	equal(t, Infinity64, NegInfinity64.Mul(negFortyTwo))
+	equal(t, NegInf, fortyTwo.Mul(NegInf))
+	equal(t, NegInf, NegInf.Mul(fortyTwo))
+	equal(t, Inf, negFortyTwo.Mul(NegInf))
+	equal(t, Inf, NegInf.Mul(negFortyTwo))
 
-	equal(t, Infinity64, Infinity64.Mul(Infinity64))
-	equal(t, Infinity64, NegInfinity64.Mul(NegInfinity64))
-	equal(t, NegInfinity64, Infinity64.Mul(NegInfinity64))
-	equal(t, NegInfinity64, NegInfinity64.Mul(Infinity64))
+	equal(t, Inf, Inf.Mul(Inf))
+	equal(t, Inf, NegInf.Mul(NegInf))
+	equal(t, NegInf, Inf.Mul(NegInf))
+	equal(t, NegInf, NegInf.Mul(Inf))
 }
 
-func checkDecimal64QuoByF(t *testing.T, f int64) {
+func checkDecimalQuoByF(t *testing.T, f int64) {
 	for i := int64(-1000 * f); i <= 1000*f; i += f {
 		for j := int64(-100); j <= 100; j++ {
-			var e Decimal64
+			var e Decimal
 			if j == 0 {
-				e = QNaN64
+				e = QNaN
 			} else {
-				e = New64FromInt64(i)
+				e = NewFromInt64(i)
 				if i == 0 && j < 0 {
 					e = e.Neg()
 				}
 			}
 			k := i * j
-			n := New64FromInt64(k)
-			d := New64FromInt64(j)
+			n := NewFromInt64(k)
+			d := NewFromInt64(j)
 			q := n.Quo(d)
 			if q != e {
 				eFlavor, eSign, eExp, eSignificand := q.parts()
@@ -225,27 +225,27 @@ func checkDecimal64QuoByF(t *testing.T, f int64) {
 	}
 }
 
-func TestDecimal64Quo(t *testing.T) {
+func TestDecimalQuo(t *testing.T) {
 	t.Parallel()
 
 	if testing.Short() {
-		t.Skip("skipping TestDecimal64Quo in short mode.")
+		t.Skip("skipping TestDecimalQuo in short mode.")
 	}
 
-	checkDecimal64QuoByF(t, 1)
-	checkDecimal64QuoByF(t, 7)
-	checkDecimal64QuoByF(t, 13)
+	checkDecimalQuoByF(t, 1)
+	checkDecimalQuoByF(t, 7)
+	checkDecimalQuoByF(t, 13)
 }
 
-func TestDecimal64Round(t *testing.T) {
+func TestDecimalRound(t *testing.T) {
 	t.Parallel()
 
 	round := func(x, y, e string) func(t *testing.T) {
 		return func(t *testing.T) {
 			t.Helper()
 
-			expected := MustParse64(e)
-			actual := DefaultContext64.Round(MustParse64(x), MustParse64(y))
+			expected := MustParse(e)
+			actual := DefaultContext.Round(MustParse(x), MustParse(y))
 			equalD64(t, expected, actual)
 		}
 	}
@@ -258,15 +258,15 @@ func TestDecimal64Round(t *testing.T) {
 	t.Run("one-100th-lg", round("2000.046", "0.01", "2000.05"))
 }
 
-func TestDecimal64Scale(t *testing.T) {
+func TestDecimalScale(t *testing.T) {
 	t.Parallel()
 
 	const limit = 380
 
 	for i := -limit; i <= limit; i += 3 {
-		x := Pi64.ScaleBInt(i)
+		x := Pi.ScaleBInt(i)
 		for j := -limit; j <= limit; j += 5 {
-			y := E64.ScaleBInt(j)
+			y := E.ScaleBInt(j)
 			expected := "1.155727349790922"
 			exp := i - j
 			switch {
@@ -283,39 +283,39 @@ func TestDecimal64Scale(t *testing.T) {
 	}
 }
 
-func TestDecimal64QuoNaN(t *testing.T) {
+func TestDecimalQuoNaN(t *testing.T) {
 	t.Parallel()
 
-	fortyTwo := New64FromInt64(42)
+	fortyTwo := NewFromInt64(42)
 
-	equal(t, QNaN64, fortyTwo.Quo(QNaN64))
-	equal(t, QNaN64, QNaN64.Quo(fortyTwo))
+	equal(t, QNaN, fortyTwo.Quo(QNaN))
+	equal(t, QNaN, QNaN.Quo(fortyTwo))
 
 }
 
-func TestDecimal64QuoInf(t *testing.T) {
+func TestDecimalQuoInf(t *testing.T) {
 	t.Parallel()
 
-	fortyTwo := New64FromInt64(42)
-	negFortyTwo := New64FromInt64(-42)
+	fortyTwo := NewFromInt64(42)
+	negFortyTwo := NewFromInt64(-42)
 
-	equal(t, Zero64, fortyTwo.Quo(Infinity64))
-	equal(t, Infinity64, Infinity64.Quo(fortyTwo))
-	equal(t, NegZero64, negFortyTwo.Quo(Infinity64))
-	equal(t, NegInfinity64, Infinity64.Quo(negFortyTwo))
+	equal(t, Zero, fortyTwo.Quo(Inf))
+	equal(t, Inf, Inf.Quo(fortyTwo))
+	equal(t, NegZero, negFortyTwo.Quo(Inf))
+	equal(t, NegInf, Inf.Quo(negFortyTwo))
 
-	equal(t, NegZero64, fortyTwo.Quo(NegInfinity64))
-	equal(t, NegInfinity64, NegInfinity64.Quo(fortyTwo))
-	equal(t, Zero64, negFortyTwo.Quo(NegInfinity64))
-	equal(t, Infinity64, NegInfinity64.Quo(negFortyTwo))
+	equal(t, NegZero, fortyTwo.Quo(NegInf))
+	equal(t, NegInf, NegInf.Quo(fortyTwo))
+	equal(t, Zero, negFortyTwo.Quo(NegInf))
+	equal(t, Inf, NegInf.Quo(negFortyTwo))
 
-	equal(t, QNaN64, Infinity64.Quo(Infinity64))
-	equal(t, QNaN64, NegInfinity64.Quo(NegInfinity64))
-	equal(t, QNaN64, Infinity64.Quo(NegInfinity64))
-	equal(t, QNaN64, NegInfinity64.Quo(Infinity64))
+	equal(t, QNaN, Inf.Quo(Inf))
+	equal(t, QNaN, NegInf.Quo(NegInf))
+	equal(t, QNaN, Inf.Quo(NegInf))
+	equal(t, QNaN, NegInf.Quo(Inf))
 }
 
-func TestDecimal64MulPo10(t *testing.T) {
+func TestDecimalMulPo10(t *testing.T) {
 	t.Parallel()
 
 	for i, u := range tenToThe128[:39] {
@@ -325,23 +325,23 @@ func TestDecimal64MulPo10(t *testing.T) {
 				continue
 			}
 			w := tenToThe128[k]
-			if !(w.hi == 0 && w.lo < decimal64Base) {
+			if !(w.hi == 0 && w.lo < decimalBase) {
 				continue
 			}
-			e := New64FromInt64(int64(w.lo))
-			a := New64FromInt64(int64(u.lo)).Mul(New64FromInt64(int64(v.lo)))
+			e := NewFromInt64(int64(w.lo))
+			a := NewFromInt64(int64(u.lo)).Mul(NewFromInt64(int64(v.lo)))
 			equalD64(t, e, a)
 		}
 	}
 }
 
-func TestDecimal64Sqrt(t *testing.T) {
+func TestDecimalSqrt(t *testing.T) {
 	t.Parallel()
 
 	for i := int64(0); i < 100000000; i = i*19/17 + 1 {
 		i2 := i * i
-		e := New64FromInt64(i)
-		n := New64FromInt64(i2)
+		e := NewFromInt64(i)
+		n := NewFromInt64(i2)
 		replayOnFail(t, func() {
 			a := n.Sqrt()
 			equalD64(t, e, a).Or(t.FailNow)
@@ -349,35 +349,35 @@ func TestDecimal64Sqrt(t *testing.T) {
 	}
 }
 
-func TestDecimal64SqrtNeg(t *testing.T) {
+func TestDecimalSqrtNeg(t *testing.T) {
 	t.Parallel()
 
-	equal(t, QNaN64, New64FromInt64(-1).Sqrt())
+	equal(t, QNaN, NewFromInt64(-1).Sqrt())
 }
 
-func TestDecimal64SqrtNaN(t *testing.T) {
+func TestDecimalSqrtNaN(t *testing.T) {
 	t.Parallel()
 
-	equal(t, QNaN64, QNaN64.Sqrt())
+	equal(t, QNaN, QNaN.Sqrt())
 }
 
-func TestDecimal64SqrtInf(t *testing.T) {
+func TestDecimalSqrtInf(t *testing.T) {
 	t.Parallel()
 
-	equal(t, Infinity64, Infinity64.Sqrt())
-	equal(t, QNaN64, NegInfinity64.Sqrt())
+	equal(t, Inf, Inf.Sqrt())
+	equal(t, QNaN, NegInf.Sqrt())
 }
 
-func TestDecimal64Sub(t *testing.T) {
+func TestDecimalSub(t *testing.T) {
 	t.Parallel()
 
-	checkDecimal64BinOp(t,
+	checkDecimalBinOp(t,
 		func(a, b int64) int64 { return a - b },
-		func(a, b Decimal64) Decimal64 { return a.Sub(b) },
+		func(a, b Decimal) Decimal { return a.Sub(b) },
 	)
 }
 
-func rnd(ctx Context64, x, y uint64) uint64 {
+func rnd(ctx Context, x, y uint64) uint64 {
 	ans, _ := ctx.round(x, y)
 	return ans
 }
@@ -385,7 +385,7 @@ func rnd(ctx Context64, x, y uint64) uint64 {
 func TestRoundHalfUp(t *testing.T) {
 	t.Parallel()
 
-	ctx := Context64{Rounding: HalfUp}
+	ctx := Context{Rounding: HalfUp}
 	equal(t, uint64(10), rnd(ctx, 10, 1))
 	equal(t, uint64(10), rnd(ctx, 11, 1))
 	equal(t, uint64(20), rnd(ctx, 15, 1))
@@ -413,7 +413,7 @@ func TestRoundHalfUp(t *testing.T) {
 func TestRoundHalfEven(t *testing.T) {
 	t.Parallel()
 
-	ctx := Context64{Rounding: HalfEven}
+	ctx := Context{Rounding: HalfEven}
 	equal(t, uint64(10), rnd(ctx, 10, 1))
 	equal(t, uint64(10), rnd(ctx, 11, 1))
 	equal(t, uint64(20), rnd(ctx, 15, 1))
@@ -441,7 +441,7 @@ func TestRoundHalfEven(t *testing.T) {
 func TestRoundHDown(t *testing.T) {
 	t.Parallel()
 
-	ctx := Context64{Rounding: Down}
+	ctx := Context{Rounding: Down}
 	equal(t, uint64(10), rnd(ctx, 10, 1))
 	equal(t, uint64(10), rnd(ctx, 11, 1))
 	equal(t, uint64(10), rnd(ctx, 15, 1))
@@ -469,60 +469,60 @@ func TestRoundHDown(t *testing.T) {
 func TestToIntegral(t *testing.T) {
 	t.Parallel()
 
-	ctx := Context64{Rounding: HalfUp}
-	equal(t, "0", ctx.ToIntegral(MustParse64("0")).String())
-	equal(t, "0", ctx.ToIntegral(MustParse64("0.499999999999999")).String())
-	equal(t, "1", ctx.ToIntegral(MustParse64("1")).String())
-	equal(t, "1", ctx.ToIntegral(MustParse64("1.49999999999999")).String())
-	equal(t, "2", ctx.ToIntegral(MustParse64("1.5")).String())
-	equal(t, "9", ctx.ToIntegral(MustParse64("9.49999999999999")).String())
-	equal(t, "10", ctx.ToIntegral(MustParse64("9.5")).String())
-	equal(t, "99", ctx.ToIntegral(MustParse64("99.499999999999")).String())
-	equal(t, "100", ctx.ToIntegral(MustParse64("99.5")).String())
+	ctx := Context{Rounding: HalfUp}
+	equal(t, "0", ctx.ToIntegral(MustParse("0")).String())
+	equal(t, "0", ctx.ToIntegral(MustParse("0.499999999999999")).String())
+	equal(t, "1", ctx.ToIntegral(MustParse("1")).String())
+	equal(t, "1", ctx.ToIntegral(MustParse("1.49999999999999")).String())
+	equal(t, "2", ctx.ToIntegral(MustParse("1.5")).String())
+	equal(t, "9", ctx.ToIntegral(MustParse("9.49999999999999")).String())
+	equal(t, "10", ctx.ToIntegral(MustParse("9.5")).String())
+	equal(t, "99", ctx.ToIntegral(MustParse("99.499999999999")).String())
+	equal(t, "100", ctx.ToIntegral(MustParse("99.5")).String())
 }
 
-func benchmarkDecimal64Data() []Decimal64 {
-	return []Decimal64{
-		One64,
-		QNaN64,
-		Infinity64,
-		NegInfinity64,
-		Pi64,
-		E64,
-		New64FromInt64(42),
-		MustParse64("9945678e100"),
-		New64FromInt64(1234567),
-		New64FromInt64(-42),
-		MustParse64("3456789e-120"),
+func benchmarkDecimalData() []Decimal {
+	return []Decimal{
+		One,
+		QNaN,
+		Inf,
+		NegInf,
+		Pi,
+		E,
+		NewFromInt64(42),
+		MustParse("9945678e100"),
+		NewFromInt64(1234567),
+		NewFromInt64(-42),
+		MustParse("3456789e-120"),
 	}
 }
 
-func BenchmarkDecimal64Abs(b *testing.B) {
-	x := benchmarkDecimal64Data()
+func BenchmarkDecimalAbs(b *testing.B) {
+	x := benchmarkDecimalData()
 	for i := 0; i < b.N; i++ {
 		_ = x[i%len(x)].Abs()
 	}
 }
 
-func BenchmarkDecimal64Add(b *testing.B) {
-	x := benchmarkDecimal64Data()
+func BenchmarkDecimalAdd(b *testing.B) {
+	x := benchmarkDecimalData()
 	y := x[:len(x)-2]
 	for i := 0; i < b.N; i++ {
 		_ = x[i%len(x)].Add(y[i%len(y)])
 	}
 }
 
-func BenchmarkDecimal64Cmp(b *testing.B) {
-	x := benchmarkDecimal64Data()
+func BenchmarkDecimalCmp(b *testing.B) {
+	x := benchmarkDecimalData()
 	y := x[:len(x)-2]
 	for i := 0; i < b.N; i++ {
 		_ = x[i%len(x)].Cmp(y[i%len(y)])
 	}
 }
 
-func BenchmarkDecimal64Mul(b *testing.B) {
-	x := One64
-	y, err := Parse64("3.142")
+func BenchmarkDecimalMul(b *testing.B) {
+	x := One
+	y, err := Parse("3.142")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -545,22 +545,22 @@ func BenchmarkFloat64Mul(b *testing.B) {
 	sink = x
 }
 
-func BenchmarkDecimal64Quo(b *testing.B) {
-	x := benchmarkDecimal64Data()
+func BenchmarkDecimalQuo(b *testing.B) {
+	x := benchmarkDecimalData()
 	for i := 0; i < b.N; i++ {
 		_ = x[i%len(x)].Mul(x[(2*i)%len(x)])
 	}
 }
 
-func BenchmarkDecimal64Sqrt(b *testing.B) {
-	x := benchmarkDecimal64Data()
+func BenchmarkDecimalSqrt(b *testing.B) {
+	x := benchmarkDecimalData()
 	for i := 0; i < b.N; i++ {
 		_ = x[i%len(x)].Sqrt()
 	}
 }
 
-func BenchmarkDecimal64Sub(b *testing.B) {
-	x := benchmarkDecimal64Data()
+func BenchmarkDecimalSub(b *testing.B) {
+	x := benchmarkDecimalData()
 	y := x[:len(x)-2]
 	for i := 0; i < b.N; i++ {
 		_ = x[i%len(x)].Sub(y[i%len(y)])
@@ -570,38 +570,38 @@ func BenchmarkDecimal64Sub(b *testing.B) {
 func TestAddOverflow(t *testing.T) {
 	t.Parallel()
 
-	equal(t, NegInfinity64, NegMax64.Sub(MustParse64("0.00000000000001e384")))
-	equal(t, Infinity64, Max64.Add(MustParse64("0.000000000000001e384")))
-	equal(t, Max64, Max64.Add(MustParse64("1")))
-	equal(t, Max64, Zero64.Add(Max64))
+	equal(t, NegInf, NegMax.Sub(MustParse("0.00000000000001e384")))
+	equal(t, Inf, Max.Add(MustParse("0.000000000000001e384")))
+	equal(t, Max, Max.Add(MustParse("1")))
+	equal(t, Max, Zero.Add(Max))
 }
 
 func TestQuoOverflow(t *testing.T) {
 	t.Parallel()
 
-	test := func(expected Decimal64, num, denom string) {
-		n := MustParse64(num)
-		d := MustParse64(denom)
+	test := func(expected Decimal, num, denom string) {
+		n := MustParse(num)
+		d := MustParse(denom)
 		if !equal(t, expected, n.Quo(d)) {
 			log.Printf("TestQuoOverflow: num = %d", n)
 			n.Quo(d)
 		}
 	}
-	test(Infinity64, "1e384", ".01")
-	test(NegInfinity64, "1e384", "-.01")
-	test(NegInfinity64, "-1e384", ".01")
-	test(NegInfinity64, "-1e384", "0")
-	test(QNaN64, "0", "0")
-	test(Zero64, "0", "100")
+	test(Inf, "1e384", ".01")
+	test(NegInf, "1e384", "-.01")
+	test(NegInf, "-1e384", ".01")
+	test(NegInf, "-1e384", "0")
+	test(QNaN, "0", "0")
+	test(Zero, "0", "100")
 }
 
 func TestMul(t *testing.T) {
 	t.Parallel()
 
-	equal(t, Infinity64, MustParse64("1e384").Mul(MustParse64("10")))
-	equal(t, NegInfinity64, MustParse64("1e384").Mul(MustParse64("-10")))
-	equal(t, NegInfinity64, MustParse64("-1e384").Mul(MustParse64("10")))
-	equal(t, NegZero64, MustParse64("-1e384").Mul(Zero64))
-	equal(t, Zero64, Zero64.Mul(Zero64))
-	equal(t, Zero64, Zero64.Mul(MustParse64("100")))
+	equal(t, Inf, MustParse("1e384").Mul(MustParse("10")))
+	equal(t, NegInf, MustParse("1e384").Mul(MustParse("-10")))
+	equal(t, NegInf, MustParse("-1e384").Mul(MustParse("10")))
+	equal(t, NegZero, MustParse("-1e384").Mul(Zero))
+	equal(t, Zero, Zero.Mul(Zero))
+	equal(t, Zero, Zero.Mul(MustParse("100")))
 }

--- a/d64/scan.go
+++ b/d64/scan.go
@@ -1,0 +1,306 @@
+package d64
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+var DefaultScanContext = DefaultFormatContext
+
+// Parse parses a string representation of a number as a [Decimal].
+// It uses [DefaultScanContext].
+func Parse(s string) (Decimal, error) {
+	return DefaultScanContext.Parse(s)
+}
+
+// Parse parses a string representation of a number as a [Decimal].
+func (ctx Context) Parse(s string) (Decimal, error) {
+	state := &scanner{reader: strings.NewReader(s)}
+	var d Decimal
+	if err := ctx.Scan(&d, state, 'e'); err != nil {
+		return d, err
+	}
+
+	// entire string must have been consumed
+	r, _, err := state.ReadRune()
+	if err == nil {
+		return QNaN, fmt.Errorf("expected end of string, found %c", r)
+	}
+	return d, nil
+}
+
+// MustParse parses a string as a [Decimal] and returns the value or
+// panics if the string doesn't represent a valid [Decimal].
+// It uses [DefaultScanContext].
+func MustParse(s string) Decimal {
+	return DefaultScanContext.MustParse(s)
+}
+
+// MustParse parses a string as a [Decimal] and returns the value or
+// panics if the string doesn't represent a valid [Decimal].
+func (ctx Context) MustParse(s string) Decimal {
+	d, err := ctx.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return d
+}
+
+// Scan implements [fmt.Scanner].
+// It uses [DefaultScanContext].
+func (d *Decimal) Scan(state fmt.ScanState, verb rune) error {
+	return DefaultScanContext.Scan(d, state, verb)
+}
+
+// Scan scans a string into a [Decimal], applying context rounding.
+func (ctx Context) Scan(d *Decimal, state fmt.ScanState, verb rune) error {
+	*d = SNaN
+	sign, err := eatRune(state, '+', '-')
+	if err != nil {
+		return err
+	}
+	if sign < 0 {
+		sign = 0
+	}
+	// Word-number: [Ii]nf(inity)?|∞|[qs]?(nan|NaN)
+	kw, err := keywords.Match(state)
+	if err != nil {
+		return err
+	}
+	switch kw {
+	case 0:
+	case 1:
+		if sign == 0 {
+			*d = Inf
+		} else {
+			*d = NegInf
+		}
+		return nil
+	case 3:
+		payload, _ := eatBytes(state, isDigit)
+		payloadInt, _, err := ctx.parseUint(payload)
+		if err != nil {
+			return err
+		}
+		*d = newPayloadNan(sign, flQNaN, uint64(payloadInt))
+		return nil
+	case 2:
+		payload, _ := eatBytes(state, isDigit)
+		payloadInt, _, err := ctx.parseUint(payload)
+		if err != nil {
+			return err
+		}
+		*d = newPayloadNan(sign, flSNaN, uint64(payloadInt))
+		return nil
+	default:
+		return errNotDecimal
+	}
+
+	whole, err := eatBytes(state, isDigit)
+	if err != nil {
+		return err
+	}
+	var buf [64]byte
+	mantissa := append(buf[:0], whole...)
+
+	if _, err := eatRune(state, '.', -1); err != nil {
+		return err
+	}
+
+	frac, err := eatBytes(state, isDigit)
+	if err != nil {
+		return err
+	}
+
+	mantissa = append(mantissa, frac...)
+	if len(mantissa) == 0 {
+		return fmt.Errorf("mantissa missing")
+	}
+
+	e, err := eatRune(state, 'e', 'E')
+	if err != nil {
+		return err
+	}
+
+	var expSign int
+	var exp []byte
+	if e != -1 {
+		expSign, err = eatRune(state, '+', '-')
+		if err != nil {
+			return err
+		}
+		if expSign < 0 {
+			expSign = 0
+		}
+		exp, err = eatBytes(state, isDigit)
+		if err != nil {
+			return err
+		}
+		if len(exp) == 0 {
+			return fmt.Errorf("exponent value missing")
+		}
+	}
+
+	significand, sExp, err := ctx.parseUint(mantissa)
+	if err != nil {
+		return err
+	}
+	if significand == 0 {
+		*d = zeroes[sign]
+		return nil
+	}
+
+	uexponent, _, err := ctx.parseUint(exp)
+	if err != nil {
+		return err
+	}
+	exponent := int64(uexponent)
+	exponent *= int64(1 - 2*expSign)
+	if exponent > 1000 {
+		*d = infinities[sign]
+		return nil
+	} else if exponent < -1000 {
+		*d = zeroes[sign]
+		return nil
+	}
+	exponent += int64(sExp - len(frac))
+
+	partExp, partSignificand := renormalize(int16(exponent), uint64(significand))
+	*d = newFromParts(int8(sign), partExp, partSignificand)
+	return nil
+}
+
+func isDigit(r rune) bool {
+	return '0' <= r && r <= '9'
+}
+
+var errNotDecimal error = Error("not a valid Decimal")
+
+func allZeros(s []byte) bool {
+	for _, c := range s {
+		if c != '0' {
+			return false
+		}
+	}
+	return true
+}
+
+func (ctx Context) parseUint(s []byte) (uint64, int, error) {
+	var a uint64
+	var exp int
+	for i, c := range s {
+		if a >= decimalBase {
+			switch ctx.Rounding {
+			case HalfUp:
+				if c >= '5' {
+					a++
+				}
+			case HalfEven:
+				if c > '5' || c == '5' && (a%2 == 1 || !allZeros(s[i+1:])) {
+					a++
+				}
+			case Down:
+			default:
+				return 0, 0, fmt.Errorf("unsupported rounding mode: %v", ctx.Rounding)
+			}
+			exp = len(s) - i
+			break
+		}
+		a = 10*a + uint64(c-'0')
+	}
+	return a, exp, nil
+}
+
+type trie struct {
+	heads  []string
+	tails  tries
+	result int
+}
+
+func trieBranch(heads string, tails ...trie) trie {
+	return trie{heads: strings.Split(heads, "|"), tails: tails}
+}
+
+func trieLeaf(heads string, result int) trie {
+	return trie{heads: strings.Split(heads, "|"), result: result}
+}
+
+type tries []trie
+
+func (tt tries) Match(state fmt.ScanState) (int, error) {
+	for _, t := range tt {
+	heads:
+		for _, head := range t.heads {
+			for i, c := range head {
+				// Try to eat the head.
+				r, _, err := state.ReadRune()
+				if err != nil {
+					if err != io.EOF {
+						return 0, err
+					}
+					continue heads
+				}
+				if r != c {
+					if i > 0 {
+						return 0, errNotDecimal
+					}
+					if err := state.UnreadRune(); err != nil {
+						return 0, err
+					}
+					continue heads
+				}
+			}
+			if len(t.tails) == 0 {
+				return t.result, nil
+			}
+			return t.tails.Match(state)
+		}
+	}
+	return 0, nil
+}
+
+var keywords = tries{
+	trieBranch("inf|Inf", trieLeaf("inity|", 1)),
+	trieLeaf("∞", 1),
+	trieBranch("s", trieLeaf("nan|NaN", 2)),
+	trieBranch("q|", trieLeaf("nan|NaN", 3)),
+}
+
+func eatBytes(state fmt.ScanState, f func(r rune) bool) ([]byte, error) {
+	token, err := state.Token(false, f)
+	if err != nil {
+		return nil, err
+	}
+	return token, err
+}
+
+// eatRune returns 0 if it reads a, 1 if it reads b, -1 otherwise.
+func eatRune(state fmt.ScanState, a, b rune) (int, error) {
+	r, _, err := state.ReadRune()
+	if err != nil {
+		if err != io.EOF {
+			return 0, err
+		}
+		return -1, nil
+	}
+	if r == a {
+		return 0, nil
+	}
+	if r == b {
+		return 1, nil
+	}
+	return -1, state.UnreadRune()
+}
+
+func newPayloadNan(sign int, fl flavor, weight uint64) Decimal {
+	s := uint64(sign) << 63
+	switch fl {
+	case flQNaN:
+		return newDec(s | QNaN.bits | weight)
+	case flSNaN:
+		return newDec(s | SNaN.bits | weight)
+	default:
+		return QNaN
+	}
+}

--- a/d64/scan_test.go
+++ b/d64/scan_test.go
@@ -1,0 +1,148 @@
+package d64
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping TestParse in short mode.")
+	}
+	parseEquals := parseEquals(t)
+
+	for i := int64(-1000); i <= 1000; i++ {
+		for _, suffix := range []string{"", ".", ".0", "e0"} {
+
+			s := strconv.Itoa(int(i))
+			di := NewFromInt64(i)
+			parseEquals(di, s+suffix)
+		}
+	}
+}
+
+func TestParseInf(t *testing.T) {
+	t.Parallel()
+
+	parseEquals := parseEquals(t)
+
+	parseEquals(Inf, "Inf")
+	parseEquals(Inf, "inf")
+	parseEquals(Inf, "∞")
+	parseEquals(NegInf, "-Inf")
+	parseEquals(NegInf, "-inf")
+	parseEquals(NegInf, "-∞")
+	parseEquals(QNaN, "nan")
+	parseEquals(QNaN, "NaN")
+}
+
+// TODO: Find out what the correct behavior is with bad inputs
+// TODO: Does nan get returned if there are leading/trailing whitespaces?
+func TestParseBadInputs(t *testing.T) {
+	t.Parallel()
+
+	test := func(input string) {
+		t.Helper()
+		d, _ := Parse(input)
+		equal(t, SNaN.IsNaN(), d.IsNaN())
+	}
+	test("")
+	test(" ")
+	test("x")
+	test("++0")
+	test("--0")
+	test("+-0")
+	test("-+0")
+	test("0..")
+	test("0..2")
+	test("0e")
+	test("0ee")
+	test("0ee2")
+	test("0ex")
+}
+
+func TestParseBigExp(t *testing.T) {
+	t.Parallel()
+
+	parseEquals := parseEquals(t)
+
+	parseEquals(Zero, "0e-9999")
+	parseEquals(NegZero, "-0e-9999")
+	parseEquals(Zero, "1e-9999")
+	parseEquals(NegZero, "-1e-9999")
+
+	parseEquals(Zero, "0e9999")
+	parseEquals(NegZero, "-0e9999")
+	parseEquals(Inf, "1e9999")
+	parseEquals(NegInf, "-1e9999")
+}
+
+func TestParseLongMantissa(t *testing.T) {
+	t.Parallel()
+
+	parseEquals := parseEquals(t)
+
+	parseEquals(One, "1000000000000000000000e-21")
+	parseEquals(NewFromInt64(123), "1230000000000000000000e-19")
+}
+
+func TestDecimalScanFlakyScanState(t *testing.T) {
+	t.Parallel()
+
+	failAt := func(text string, failAt int) {
+		state := flakyScanState{
+			actual: &scanner{reader: strings.NewReader(text)},
+			failAt: failAt,
+		}
+		var d Decimal
+		notnil(t, d.Scan(&state, 'e'))
+	}
+
+	failAt("x", 0)
+	for i := 0; i < 7; i++ {
+		failAt("-1.0e-3", i)
+	}
+}
+
+func BenchmarkIOParse(b *testing.B) {
+	var d Decimal
+	for n := 0; n < b.N; n++ {
+		buf := bytes.NewBufferString("123456789")
+		fmt.Fscanf(buf, "%g", &d) //nolint:errcheck
+	}
+}
+
+func BenchmarkIODecimalScan(b *testing.B) {
+	reader := strings.NewReader("")
+	for n := 0; n < b.N; n++ {
+		reader.Reset("123456789")
+		var d Decimal
+		if err := d.Scan(&scanner{reader: reader}, 'g'); err != nil {
+			panic("Benchmarking Scan failed")
+		}
+	}
+}
+
+func parseEquals(t *testing.T) func(expected Decimal, input string) {
+	return func(expected Decimal, input string) {
+		nopanic(t, func() {
+			n := MustParse(input)
+			equalD64(t, expected, n)
+		})
+
+		n, err := Parse(input)
+		isnil(t, err)
+		equalD64(t, expected, n)
+
+		n = SNaN
+		count, err := fmt.Sscanf(input, "%g", &n)
+		isnil(t, err)
+		equal(t, 1, count)
+		equalD64(t, expected, n)
+	}
+}

--- a/d64/stringScanner.go
+++ b/d64/stringScanner.go
@@ -1,0 +1,75 @@
+package d64
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"unicode"
+)
+
+type runeScanner interface {
+	io.Reader
+	io.RuneScanner
+}
+
+type scanner struct {
+	reader runeScanner
+}
+
+var _ fmt.ScanState = (*scanner)(nil)
+
+func (s *scanner) ReadRune() (r rune, size int, err error) {
+	return s.reader.ReadRune()
+}
+
+func (s *scanner) UnreadRune() error {
+	return s.reader.UnreadRune()
+}
+
+func (s *scanner) SkipSpace() {
+	for {
+		ch, _, err := s.ReadRune()
+		if err != nil {
+			break
+		}
+		if !unicode.IsSpace(ch) {
+			if err := s.UnreadRune(); err != nil {
+				panic("s.UnreadRune() failed")
+			}
+			break
+		}
+	}
+}
+
+func (s *scanner) Token(skipSpace bool, f func(rune) bool) (token []byte, err error) {
+	if skipSpace {
+		s.SkipSpace()
+	}
+
+	var buf bytes.Buffer
+	for {
+		r, _, err := s.ReadRune()
+		if err != nil {
+			if err != io.EOF {
+				return nil, err
+			}
+			break
+		}
+		if !f(r) {
+			if err := s.UnreadRune(); err != nil {
+				return nil, err
+			}
+			break
+		}
+		buf.WriteRune(r)
+	}
+	return buf.Bytes(), nil
+}
+
+func (s *scanner) Width() (wid int, ok bool) {
+	return 0, false
+}
+
+func (s *scanner) Read(buf []byte) (n int, err error) {
+	return s.reader.Read(buf)
+}

--- a/d64/stringScanner_test.go
+++ b/d64/stringScanner_test.go
@@ -1,0 +1,57 @@
+package d64
+
+import (
+	"strings"
+	"testing"
+	"unicode"
+)
+
+func TestStringScannerSkipSpace(t *testing.T) {
+	t.Parallel()
+
+	state := &scanner{reader: strings.NewReader(" \tx")}
+
+	state.SkipSpace()
+
+	r, size, err := state.ReadRune()
+	isnil(t, err)
+	equal(t, 1, size)
+	equal(t, 'x', r)
+
+	nopanic(t, func() { state.SkipSpace() })
+}
+
+func TestStringScannerTokenSkipSpace(t *testing.T) {
+	t.Parallel()
+
+	state := &scanner{reader: strings.NewReader(" \txyz")}
+
+	token, err := state.Token(false, unicode.IsLetter)
+	isnil(t, err)
+	equal(t, 0, len(token))
+
+	token, err = state.Token(true, unicode.IsLetter)
+	isnil(t, err)
+	equal(t, "xyz", string(token))
+}
+
+func TestStringScannerRead(t *testing.T) {
+	t.Parallel()
+
+	state := &scanner{reader: strings.NewReader("hello world!")}
+
+	var hello [5]byte
+	var world [10]byte
+
+	n, err := state.Read(hello[:])
+	isnil(t, err)
+	equal(t, 5, n)
+	equal(t, "hello", string(hello[:]))
+
+	state.SkipSpace()
+
+	n, err = state.Read(world[:])
+	isnil(t, err)
+	equal(t, 6, n)
+	equal(t, "world!", string(world[:n]))
+}

--- a/d64/uint128.go
+++ b/d64/uint128.go
@@ -1,0 +1,163 @@
+package d64
+
+import (
+	"math"
+	"math/bits"
+	"sync"
+)
+
+type uint128T struct {
+	lo, hi uint64
+}
+
+func (a *uint128T) numDecimalDigits() int {
+	if a.hi == 0 {
+		return numDecimalDigitsU64(a.lo)
+	}
+	bitSize := 65 + bits.Len64(a.hi)
+	numDigitsEst := uint(bitSize) * 77 / 256
+	if !a.lt(&tenToThe128[numDigitsEst%uint(len(tenToThe128))]) {
+		numDigitsEst++
+	}
+	return int(numDigitsEst)
+}
+
+// numDecimalDigitsU64 returns the magnitude (number of digits) of a uint64.
+func numDecimalDigitsU64(n uint64) int {
+	numDigits := uint(bits.Len64(n)) * 77 / 256 // ~ 3/10
+	if n >= tenToThe[numDigits%uint(len(tenToThe))] {
+		numDigits++
+	}
+	return int(numDigits)
+}
+
+var tenToThe128 = func() [64]uint128T {
+	var ans [64]uint128T
+	for i := range ans[:39] {
+		ans[i].umul64(tenToThe[i/2], tenToThe[(i+1)/2])
+	}
+	return ans
+}()
+
+func (a *uint128T) umul64(x, y uint64) *uint128T {
+	a.hi, a.lo = bits.Mul64(x, y)
+	return a
+}
+
+func (a *uint128T) add(x, y *uint128T) *uint128T {
+	var carry uint64
+	a.lo, carry = bits.Add64(x.lo, y.lo, 0)
+	a.hi, _ = bits.Add64(x.hi, y.hi, carry)
+	return a
+}
+
+func (a *uint128T) sub(x, y *uint128T) *uint128T {
+	var borrow uint64
+	a.lo, borrow = bits.Sub64(x.lo, y.lo, 0)
+	a.hi, _ = bits.Sub64(x.hi, y.hi, borrow)
+	return a
+}
+
+func (a *uint128T) divrem64(x *uint128T, d uint64) uint64 {
+	var r uint64
+	if a.hi == 0 {
+		a.lo, r = x.lo/d, x.lo%d
+	} else {
+		a.hi, r = bits.Div64(0, x.hi, d)
+		a.lo, r = bits.Div64(r, x.lo, d)
+	}
+	return r
+}
+
+// divbase divides a by [decimal64Base].
+func (a *uint128T) divbase(x *uint128T) *uint128T { return a.divc(x, 113, 0x901d7cf73ab0acd9) }
+
+// div10base divides a by 10*[decimal64Base].
+func (a *uint128T) div10base(x *uint128T) *uint128T { return a.divc(x, 117, 0xe69594bec44de15b) }
+
+// divc divides a by n where 1<<po2/rdenom ~ n and po2 is chosen such that rdenom is the largest possible value < 1<<64.
+func (a *uint128T) divc(x *uint128T, po2 int, rdenom uint64) *uint128T {
+	m := x.hi<<(64-43) + x.lo>>43 // (hi, lo) >> 43
+	q, _ := bits.Mul64(m, rdenom)
+	return a.set(0, q>>(po2-(43+64))+1)
+}
+
+func (a *uint128T) lt(b *uint128T) bool {
+	if a.hi != b.hi {
+		return a.hi < b.hi
+	}
+	return a.lo < b.lo
+}
+
+func (a *uint128T) mul(x, y *uint128T) *uint128T {
+	var t, u uint128T
+	t.umul64(x.hi, y.lo)
+	u.umul64(x.lo, y.hi)
+	t.add(&t, &u)
+	t = uint128T{0, t.lo} // t <<= 64
+	u.umul64(x.lo, y.lo)
+	return a.add(&t, &u)
+}
+
+func (a *uint128T) mul64(x *uint128T, b uint64) *uint128T {
+	var t uint128T
+	y := uint128T{0, t.umul64(x.hi, b).lo}
+	return a.add(&y, t.umul64(x.lo, b))
+}
+
+func (a *uint128T) shl(b *uint128T, s uint) *uint128T {
+	if s < 64 {
+		return a.set(b.lo>>(64-s)|b.hi<<s, b.lo<<s)
+	}
+	return a.set(b.lo<<(s-64), 0)
+}
+
+func (a *uint128T) set(hi, lo uint64) *uint128T {
+	*a = uint128T{lo, hi}
+	return a
+}
+
+func sqrtu64(n uint64) uint64 {
+	const maxu32 = 1<<32 - 1
+	switch {
+	case n < 1<<16:
+		return uint64(sqrtu16(uint16(n)) >> 8)
+	case n >= maxu32*maxu32:
+		return maxu32
+	}
+
+	// Shift up as far as possible, but must be an even amount.
+	halfshift := bits.LeadingZeros64(n) / 2
+	n <<= 2 * halfshift
+
+	s := sqrtu16(uint16(n >> (64 - 16)))
+	x := uint64(s) << (32 - 16)
+
+	// Two iterations suffice.
+	x = (x + n/x) >> 1
+	// Undo shift in second iteration. Only need 1/2-shift because it's the √.
+	return (x + n/x) >> (1 + halfshift)
+}
+
+const (
+	sqrtSlotSize = 64 / 2 // 1 cache line
+	sqrtElts     = 1 << 16
+)
+
+var (
+	sqrtTable [sqrtElts]uint16
+	sqrtOnce  [sqrtElts / sqrtSlotSize]sync.Once
+)
+
+// sqrtu16 returns √n << 8.
+func sqrtu16(n uint16) uint16 {
+	slot := n / sqrtSlotSize
+	sqrtOnce[slot].Do(func() {
+		a := slot * sqrtSlotSize
+		b := a + sqrtSlotSize
+		for i := a; i != b; i++ { // != because b wraps
+			sqrtTable[i] = uint16(math.Sqrt(float64(uint64(i) << 16)))
+		}
+	})
+	return sqrtTable[n]
+}

--- a/d64/uint128_test.go
+++ b/d64/uint128_test.go
@@ -1,0 +1,105 @@
+package d64
+
+import (
+	"math/bits"
+	"math/rand"
+	"testing"
+)
+
+func TestUint128Shl(t *testing.T) {
+	t.Parallel()
+
+	test := func(expected, original uint128T, shift uint) {
+		t.Helper()
+		original.shl(&original, shift)
+		equal(t, expected, original)
+	}
+	test(uint128T{}, uint128T{}, 1)
+	test(uint128T{2, 0}, uint128T{1, 0}, 1)
+	test(uint128T{4, 0}, uint128T{2, 0}, 1)
+	test(uint128T{4, 0}, uint128T{1, 0}, 2)
+	test(uint128T{0, 1}, uint128T{1, 42}, 64)
+	test(uint128T{0, 3}, uint128T{3, 42}, 64)
+}
+
+func TestNumDecimalDigits(t *testing.T) {
+	t.Parallel()
+
+	for i, num := range tenToThe {
+		for j := uint64(1); j < 10 && i < 19; j++ {
+			equal(t, i+1, int(numDecimalDigitsU64(num*j)))
+		}
+	}
+}
+
+func TestSqrtu64(t *testing.T) {
+	t.Parallel()
+
+	test := func(n uint64) {
+		t.Helper()
+		replayOnFail(t, func() {
+			t.Helper()
+			s := sqrtu64(n)
+			sq := s * s
+			s1q := (s + 1) * (s + 1)
+			// s1q < sq handles overflow cases.
+			check(t, sq <= n && (s1q < sq || s1q >= n)).Or(t.FailNow)
+		})
+	}
+
+	// Fibonacci numbers, just because
+	var a, b uint64 = 1, 1
+	for a < b {
+		test(a)
+		a, b = b, a+b
+	}
+
+	hi := uint64(1<<64 - 1)
+
+	for i := 0; i < 64; i++ {
+		n := uint64(1) << i
+		test(n)
+		test(hi - n)
+	}
+
+	for i := uint64(0); i < 100_000; i++ {
+		test(i)
+		test(hi - i)
+	}
+
+	// (2**64)**1e-6 ~ 1.00004
+	for i := uint64(100_000); i < (1<<64)*99_999/100_004; {
+		test(i)
+		test(hi - i)
+		a, b := bits.Mul64(i, 100_004)
+		i, _ = bits.Div64(a, b, 100_000)
+	}
+
+	s := rand.NewSource(0).(rand.Source64)
+	for i := 0; i < 1_000_000; i++ {
+		test(s.Uint64())
+	}
+}
+
+func TestSqrtu16(t *testing.T) {
+	t.Parallel()
+
+	test := func(n uint16) {
+		t.Helper()
+		replayOnFail(t, func() {
+			t.Helper()
+			s := sqrtu16(n) >> 8
+			sq := uint32(s) * uint32(s)
+			s1q := uint32(s+1) * uint32(s+1)
+			// s1q < sq handles overflow cases.
+			check(t, sq <= uint32(n) && (s1q < sq || s1q >= uint32(n))).Or(t.FailNow)
+		})
+	}
+
+	for i := uint16(0); i < 1<<16-1; i++ {
+		test(i)
+	}
+	test(1<<16 - 1)
+	// fmt.Printf("%#v\n", sqrtTable)
+	// t.Fail()
+}

--- a/d64/util_test.go
+++ b/d64/util_test.go
@@ -1,0 +1,129 @@
+package d64
+
+import "testing"
+
+func replayOnFail(t *testing.T, f func()) pass {
+	t.Helper()
+	alreadyFailed := t.Failed()
+	defer func() {
+		t.Helper()
+		if r := recover(); r != nil {
+			t.Errorf("panic: %+v", r)
+		}
+		if !alreadyFailed && t.Failed() {
+			f() // Set a breakpoint here to replay the first failed test.
+		}
+	}()
+	f()
+	return !pass(alreadyFailed && t.Failed())
+}
+
+type pass bool
+
+func (p pass) Or(f func()) {
+	if !p {
+		f()
+	}
+}
+
+func check(t *testing.T, ok bool) pass {
+	t.Helper()
+	if !ok {
+		t.Errorf("expected true")
+		return false
+	}
+	return true
+}
+
+func epsilon(t *testing.T, a, b float64) pass {
+	t.Helper()
+	if a/b-1 > 0.00000001 {
+		t.Errorf("%f and %f too dissimilar", a, b)
+		return false
+	}
+	return true
+}
+
+func equal[T comparable](t *testing.T, a, b T) pass {
+	t.Helper()
+	if a != b {
+		t.Errorf("expected %+v, got %+v", a, b)
+		return false
+	}
+	return true
+}
+
+func equalD64(t *testing.T, expected, actual Decimal) pass {
+	t.Helper()
+	return equal(t, expected.String(), actual.String())
+}
+
+func isnil(t *testing.T, a any) pass {
+	t.Helper()
+	if a != nil {
+		t.Errorf("expected nil, got %+v", a)
+		return false
+	}
+	return true
+}
+
+func nopanic(t *testing.T, f func()) (b pass) {
+	t.Helper()
+	defer func() {
+		t.Helper()
+		if r := recover(); r != nil {
+			t.Errorf("panic: %+v", r)
+			b = false
+		}
+	}()
+	f()
+	return true
+}
+
+func notequal[T comparable](t *testing.T, a, b T) pass {
+	t.Helper()
+	if a == b {
+		t.Errorf("equal values %+v", a)
+		return false
+	}
+	return true
+}
+
+func notnil(t *testing.T, a any) pass {
+	t.Helper()
+	if a == nil {
+		t.Errorf("expected non-nil")
+		return false
+	}
+	return true
+}
+
+func panics(t *testing.T, f func()) (b pass) {
+	t.Helper()
+	defer func() {
+		t.Helper()
+		if r := recover(); r == nil {
+			t.Errorf("expected panic")
+			b = false
+		}
+	}()
+	f()
+	return true
+}
+
+func TestUmul64_po10(t *testing.T) {
+	t.Parallel()
+
+	for i, u := range tenToThe128[:39] {
+		if u.hi == 0 {
+			for j, v := range tenToThe128[:39] {
+				if v.hi == 0 {
+					e := tenToThe128[i+j]
+					var a uint128T
+					a.umul64(u.lo, v.lo)
+					equal(t, e, a)
+				}
+			}
+		}
+	}
+}

--- a/decimal64math_test.go
+++ b/decimal64math_test.go
@@ -237,27 +237,6 @@ func TestDecimal64Quo(t *testing.T) {
 	checkDecimal64QuoByF(t, 13)
 }
 
-func TestDecimal64Round(t *testing.T) {
-	t.Parallel()
-
-	round := func(x, y, e string) func(t *testing.T) {
-		return func(t *testing.T) {
-			t.Helper()
-
-			expected := MustParse64(e)
-			actual := DefaultContext64.Round(MustParse64(x), MustParse64(y))
-			equalD64(t, expected, actual)
-		}
-	}
-
-	t.Run("one", round("2", "1", "2"))
-	t.Run("zero", round("2", "0", "0"))
-	t.Run("ten", round(("-2"), "10", "-0"))
-	t.Run("one-10th", round("2", "0.1", "2"))
-	t.Run("one-100th", round("2", "0.01", "2"))
-	t.Run("one-100th-lg", round("2000.046", "0.01", "2000.05"))
-}
-
 func TestDecimal64Scale(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
1. Refactor the `decimal` package to `decimal/d64`.
2. Tag `decimal` package as deprecated.
3. Update `README.md`.
